### PR TITLE
Trac #33396: Customizer: focusing a control outside of a panel when a panel is open results in a blank screen with no navigation back

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1260,7 +1260,7 @@
 
 				// Collapse any sibling sections/panels
 				api.section.each( function ( section ) {
-					if ( ! section.panel() ) {
+					if ( panel.id !== section.panel() ) {
 						section.collapse( { duration: 0 } );
 					}
 				});

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -648,6 +648,9 @@
 						completeCallback: expand
 					});
 				} else {
+					api.panel.each( function( panel ) {
+						panel.collapse();
+					});
 					expand();
 				}
 

--- a/src/wp-includes/default-widgets.php
+++ b/src/wp-includes/default-widgets.php
@@ -1574,8 +1574,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 		<p class="nav-menu-widget-no-menus-message" <?php if ( ! empty( $menus ) ) { echo ' style="display:none" '; } ?>>
 			<?php
 			if ( isset( $GLOBALS['wp_customize'] ) && $GLOBALS['wp_customize'] instanceof WP_Customize_Manager ) {
-				// @todo When expanding a panel, the JS should be smart enough to collapse any existing panels and sections.
-				$url = 'javascript: wp.customize.section.each(function( section ){ section.collapse(); }); wp.customize.panel( "nav_menus" ).focus();';
+				$url = 'javascript: wp.customize.panel( "nav_menus" ).focus();';
 			} else {
 				$url = admin_url( 'nav-menus.php' );
 			}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/33396