### PR TITLE
Trac-33431 : "(Currently set to: %s)" string needs context

### DIFF
--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -337,7 +337,7 @@ final class WP_Customize_Nav_Menus {
 				'unnamed'           => _x( '(unnamed)', 'Missing menu name.' ),
 				'custom_label'      => __( 'Custom Link' ),
 				/* translators: %s: Current menu location */
-				'menuLocation'      => __( '(Currently set to: %s)' ),
+				'menuLocation'      => _x( '(Currently set to: %s)', 'Current menu location' ),
 				'menuNameLabel'     => __( 'Menu Name' ),
 				'itemAdded'         => __( 'Menu item added' ),
 				'itemDeleted'       => __( 'Menu item deleted' ),

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-control.php
@@ -71,7 +71,7 @@ class WP_Customize_Nav_Menu_Control extends WP_Customize_Control {
 			<li class="customize-control customize-control-checkbox assigned-menu-location">
 				<label>
 					<input type="checkbox" data-menu-id="{{ data.menu_id }}" data-location-id="<?php echo esc_attr( $location ); ?>" class="menu-location" /> <?php echo $description; ?>
-					<span class="theme-location-set"><?php printf( _x( '(Current: %s)', 'Current menu location' ), '<span class="current-menu-location-name-' . esc_attr( $location ) . '"></span>' ); ?></span>
+					<span class="theme-location-set"><?php printf( /* translators: %s: menu name */ _x( '(Current: %s)', 'Current menu location' ), '<span class="current-menu-location-name-' . esc_attr( $location ) . '"></span>' ); ?></span>
 				</label>
 			</li>
 			<?php endforeach; ?>


### PR DESCRIPTION
This PR for [Trac-33431](https://core.trac.wordpress.org/ticket/33431) adds translator information for the menu location.
In data passed to the JavaScript array, it adds translator context after `(Currently set to: %s)`.
And in the Customizer nav menu control, it adds a translator comment to indicate the menu name.