### PR TITLE
trac-34755 : Change string in '(Currently set to: %s)' to location name

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -805,19 +805,20 @@
 		/**
 		 * @param {array} themeLocations
 		 */
-		updateAssignedLocationsInSectionTitle: function( themeLocations ) {
+		updateAssignedLocationsInSectionTitle: function( themeLocationSlugs ) {
 			var section = this,
 				$title;
 
 			$title = section.container.find( '.accordion-section-title:first' );
 			$title.find( '.menu-in-location' ).remove();
-			_.each( themeLocations, function( themeLocation ) {
+			_.each( themeLocationSlugs, function( themeLocationSlug ) {
 				var $label = $( '<span class="menu-in-location"></span>' );
-				$label.text( api.Menus.data.l10n.menuLocation.replace( '%s', themeLocation ) );
+				var locationName = api.Menus.data.locationSlugMappedToName[ themeLocationSlug ];
+				$label.text( api.Menus.data.l10n.menuLocation.replace( '%s', locationName ) );
 				$title.append( $label );
 			});
 
-			section.container.toggleClass( 'assigned-to-menu-location', 0 !== themeLocations.length );
+			section.container.toggleClass( 'assigned-to-menu-location', 0 !== themeLocationSlugs.length );
 
 		},
 

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -381,6 +381,7 @@ final class WP_Customize_Nav_Menus {
 				'nav_menu'      => $temp_nav_menu_setting->default,
 				'nav_menu_item' => $temp_nav_menu_item_setting->default,
 			),
+			'locationSlugMappedToName' => get_registered_nav_menus(),
 		);
 
 		$data = sprintf( 'var _wpCustomizeNavMenusSettings = %s;', wp_json_encode( $settings ) );


### PR DESCRIPTION
This PR for [trac-34755](https://core.trac.wordpress.org/ticket/34755) changes the "Menu Location" string in Customizer menu controls to the location name. Before, this string was the location slug.

So this adds an object to the data passed to the Customizer : `locationSlugMappedToName`. And uses this to retrieve the location name.

This also changes the argument name from `themeLocations` to `themeLocationSlugs`. This doesn't change the argument, it only clarifies the fact that it consists of slugs.