### PR TITLE
Trac 35947 : Customizer panel fails to fully expand leaving extra margin 

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -430,6 +430,14 @@ h3.customize-section-title {
 	width: 300px;
 }
 
+.in-sub-panel #customize-info {
+	height: 0;
+}
+
+.in-sub-panel #customize-theme-controls > ul > .control-section:not(.current-panel) {
+	height: 0;
+}
+
 .in-sub-panel #customize-theme-controls .accordion-section.current-panel {
 	width: 100%;
 }

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1363,7 +1363,6 @@
 					content.parent().show();
 					position = content.offset().top;
 					scroll = container.scrollTop();
-					content.css( 'margin-top', ( headerActionsHeight - position - scroll ) );
 					accordionSection.addClass( 'current-panel' );
 					overlay.addClass( 'in-sub-panel' );
 					container.scrollTop( 0 );


### PR DESCRIPTION
@westonruter,
This pull request for [trac-35497](https://core.trac.wordpress.org/ticket/35947) removes extra space at bottom of Customizer panel. As the [ticket](https://core.trac.wordpress.org/ticket/35947) notes, there's "unnecessary spacing when you go inside a panel." 

This occurs when there are many panels, using the code provided in the [ticket](https://core.trac.wordpress.org/ticket/35947) to produce the panels. The non-active sections and panels still occupied space in the DOM. So the active panel had a `margin-top` property to move it to the top.

This PR [sets](https://github.com/xwp/wordpress-develop/compare/master...trac-35947#diff-6bdd5041777c50e624f1d0beae2e0b7cR437) the height of the non-active sections to `0`. And it [doesn't add](https://github.com/xwp/wordpress-develop/compare/master...trac-35947#diff-58dfe22165ffd9650354f7bdd51002ecL1366) a `margin-top` value to the active panel's content.

I tested this with the test code on the [ticket](https://core.trac.wordpress.org/ticket/35947) on the following themes. There was no longer a space at the bottom of the panels. I couldn't find any side-effects. 
[Graphene](https://wordpress.org/themes/graphene/)
[Heuman](https://wordpress.org/themes/hueman/)
[Customizr](https://wordpress.org/themes/customizr)
[Twenty Fifteen](https://wordpress.org/themes/twentyfifteen)
[Twenty Sixteen](https://wordpress.org/themes/twentysixteen)