### PR TITLE
Remove horizontal gap next to scrollbar when opening a panel.

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1367,14 +1367,16 @@
 					accordionSection.addClass( 'current-panel' );
 					overlay.addClass( 'in-sub-panel' );
 					container.scrollTop( 0 );
-					if ( args.completeCallback ) {
-						args.completeCallback();
-					}
+					topPanel.attr( 'tabindex', '-1' );
+					backBtn.attr( 'tabindex', '0' );
+					panel._recalculateTopMargin();
+					_.delay( function() {
+						backBtn.focus();
+						if ( args.completeCallback ) {
+							args.completeCallback();
+						}
+					}, 180 );
 				} );
-				topPanel.attr( 'tabindex', '-1' );
-				backBtn.attr( 'tabindex', '0' );
-				backBtn.focus();
-				panel._recalculateTopMargin();
 			} else {
 				siblings.removeClass( 'open' );
 				accordionSection.removeClass( 'current-panel' );


### PR DESCRIPTION
**Different approach proposal**

I have pushed my proposal for the fix to the issue. Instead of removing `_recalculateTopMargin()` which is risky in current sliding panels implementation and [may cause new issues](https://core.trac.wordpress.org/ticket/35947#comment:6), I have delayed focus event on back button.

While working on [#34391](https://core.trac.wordpress.org/ticket/34391), I've noticed that focusing on element during CSS transition may cause unexpected results, very similar to the one presented. In case of [#34391](https://core.trac.wordpress.org/ticket/34391) I have implemented full solution taking advantage of `transitionEnd` event listening. In case of this ticket, I have used simpler solution - `focus()` is delayed by 180 ms which is the time needed for the transition to end.

I've tested the fix on Chrome/OS X, Firefox/OS X, Firefox/Windows 8.1, Firefox/Windows 7, IE11/Windows 7 (Twenty Sixteen in each case).

@kienstra, @westonruter: it'd be great if you could double check the fix works for you as expected. _As a side note: I was able to reproduce the original issue only in Firefox._

**I have created new branch and PR so that the patch file doesn't contain previous commits and their reverts.**