### PR TITLE
Trac-34344: Expanded section margin-top glitches when other section is deactivated

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -459,6 +459,14 @@ h3.customize-section-title {
 	overflow-y: hidden;
 }
 
+.wp-full-overlay.section-open #customize-theme-controls > ul > .accordion-section {
+	height: 0;
+}
+
+.wp-full-overlay.section-open #customize-theme-controls > ul > .accordion-section.open {
+	height: auto;
+}
+
 .wp-full-overlay.section-open .wp-full-overlay-sidebar-content .accordion-section.open {
 	visibility: visible;
 }


### PR DESCRIPTION
**Request For Review**

@westonruter,
Could you please review this pull request for [trac-34344](https://core.trac.wordpress.org/ticket/34344#comment:7)? 

**Defect:** After opening a widget section, and de-activating another section, the section moves up too high ([your screenshot](https://core.trac.wordpress.org/attachment/ticket/34344/section-margin-top-problem.png)).

**Fix:** This [sets](https://github.com/xwp/wordpress-develop/compare/trac-34344-2?expand=1#diff-6bdd5041777c50e624f1d0beae2e0b7cR463) the height to `0` for all sections in the root panel that aren't open.

**Reason:** Like we saw in [trac-35947](https://core.trac.wordpress.org/ticket/35947), non-open sections still took up space in the DOM. And they caused problems with the calculation of the margin-top value.

For example,  [trac-34344](https://core.trac.wordpress.org/ticket/34344#comment:7) gives this code to reproduce the bug:

`wp.customize.section('header_image').expand( { completeCallback: function() { 
         _.delay( function(){ wp.customize.section('colors').active(false); }, 1000 ); 
} } );`

This opens the `header_image` section, and de-activates the `colors` section. But the `colors` section had a height of `43px`. So when it's de-activated, it is given `display: none`. And it's taken out of the DOM.

But the `margin-top` of the `header_image` content area was already set at `-259px`. So when the `colors` section moves out of the DOM, the `header_image` section moves too high.


This is similar to @delawski's [commit](https://github.com/xwp/wordpress-develop/commit/89591f9e3c3ae42b6b1c40b350f30c51c90892fa) for [trac-35947](https://core.trac.wordpress.org/ticket/35947). 