### PR TITLE
Customize : Menu and widget search field UI changes.

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1422,8 +1422,40 @@ body.adding-widget .add-new-widget:before,
 
 #available-widgets-filter input,
 #available-menu-items-search input {
-	padding: 6px 10px;
+	padding: 6px 10px 6px 30px;
 	width: 100%;
+}
+
+#available-menu-items-search input {
+	padding-right: 30px;
+}
+
+#available-menu-items-search input::-ms-clear {
+	display: none; /* remove the "x" in IE, which conflicts with the "x" icon on button.clear-results */
+}
+
+#available-menu-items-search .search-icon,
+#available-widgets-filter .search-icon {
+	display: block;
+	position: absolute;
+	top: 18px;
+	left: 20px;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	border: 0;
+	background: none;
+	text-decoration: none;
+	outline: 0;
+}
+
+#available-menu-items-search .search-icon:after,
+#available-widgets-filter .search-icon:after {
+	content: "\f179";
+	font: normal 20px/1 dashicons;
+	vertical-align: middle;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 #available-widgets .widget-top,

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -625,10 +625,10 @@
 
 #available-menu-items-search .clear-results {
 	position: absolute;
-	top: 18px; /* 12 container padding +1 input margin +1 input border +4 ( 4 is ( 28 input height - 20 button height ) / 2 ) */
-	right: 20px;
-	width: 20px;
-	height: 20px;
+	top: 13px; /* 12 container padding +1 input margin +1 input border +4 ( 4 is ( 28 input height - 20 button height ) / 2 ) */
+	right: 15px;
+	width: 30px;
+	height: 30px;
 	padding: 0;
 	border: 0;
 	cursor: pointer;

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -767,6 +767,7 @@ final class WP_Customize_Nav_Menus {
 					<p class="screen-reader-text" id="menu-items-search-desc"><?php _e( 'The search results will be updated as you type.' ); ?></p>
 					<span class="spinner"></span>
 				</div>
+				<div class="search-icon"></div>
 				<button type="button" class="clear-results"><span class="screen-reader-text"><?php _e( 'Clear Results' ); ?></span></button>
 				<ul class="accordion-section-content" data-type="search"></ul>
 			</div>

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -778,6 +778,7 @@ final class WP_Customize_Widgets {
 			<div id="available-widgets-filter">
 				<label class="screen-reader-text" for="widgets-search"><?php _e( 'Search Widgets' ); ?></label>
 				<input type="search" id="widgets-search" placeholder="<?php esc_attr_e( 'Search widgets&hellip;' ) ?>" />
+				<div class="search-icon"></div>
 			</div>
 			<div id="available-widgets-list">
 			<?php foreach ( $this->get_available_widgets() as $available_widget ): ?>


### PR DESCRIPTION
**Request For Review**

Could you please review this pull request for [#36908](https://core.trac.wordpress.org/ticket/36908)? Here's a [screenshot](https://cloudup.com/cFRQ_Zxg8QZ) of the search field that appears on clicking a menu's "Add Items" button.

* Create [search icon](https://github.com/xwp/wordpress-develop/compare/trac-36908?expand=1#diff-49c6fb18cfad3f9946aa8ca15b809b3fR770) in `<input>`, using neighbor `<div>` with [:after](https://github.com/xwp/wordpress-develop/compare/trac-36908?expand=1#diff-6bdd5041777c50e624f1d0beae2e0b7cR1453).
It's not possible to set this as a `:before` or `:after` psuedo-element of the `<input>`.
[Increase padding-left](https://github.com/xwp/wordpress-develop/compare/trac-36908?expand=1#diff-6bdd5041777c50e624f1d0beae2e0b7cR1425) from `10px` to `30px` to create space for this.
Mainly copy styling of .clear-results in [customize-nav-menus.css#L626](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/css/customize-nav-menus.css#L626).
In menu search field, [increase clickable area](https://github.com/xwp/wordpress-develop/compare/trac-36908?expand=1#diff-79f9bc58f474eba515dbb6e2822b7a22R628) of x icon. 

This [ticket's](https://core.trac.wordpress.org/ticket/36908) description states 
```Not sure about the widgets search field, ideally it would be great to pair it with the menu items search and implement the same custom control to clear the field.```

Would you like the "widgets search field" to have the "same custom control" (red "x" button)? So far, this only appears in the [menu search field](https://cloudup.com/cFRQ_Zxg8QZ)?