### PR TITLE
Trac 38021 : Remove Customizer support for IE8.

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2169,7 +2169,7 @@ function wp_customize_support_script() {
 <?php		endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
-			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
+			b[c] += ( window.postMessage && request && Array.prototype.indexOf ? ' ' : ' no-' ) + cs;
 		}());
 	</script>
 	<?php

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2169,6 +2169,7 @@ function wp_customize_support_script() {
 <?php		endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
+			// The customizer requires postMessage and CORS (if the site is cross domain)
 			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
 		}());
 	</script>

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2169,9 +2169,13 @@ function wp_customize_support_script() {
 <?php		endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
-			b[c] += ( window.postMessage && request && Array.prototype.indexOf ? ' ' : ' no-' ) + cs;
+			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
 		}());
 	</script>
+
+	<!--[if lte IE 8]><script type="text/javascript">
+		document.body.className = document.body.className.replace( 'customize-support', 'no-customize-support' );
+	</script><![endif]-->
 	<?php
 }
 


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter,
Could you please review this pull request for [#38021](https://core.trac.wordpress.org/ticket/38021) (Customize: remove support for IE8)?

* [0e873b](https://github.com/xwp/wordpress-develop/commit/0e873bdcab65bd84e7af0b294e5c4433cd708ed0) : Customize: Remove Customizer support for IE8.
[wp_customize_support_script()](https://github.com/xwp/wordpress-develop/compare/trac-38021?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2155) adds a class to `<body>`,
to indicate Customizer support. And it has a [conditional](https://github.com/xwp/wordpress-develop/compare/trac-38021?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2172) to control which class to add.
So add `Array.prototype.indexOf` to this [conditional](https://github.com/xwp/wordpress-develop/compare/trac-38021?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2172).
As [Weston found](https://core.trac.wordpress.org/ticket/30781#trac-change-12-1419099917614426) in #30781, this is undefined in IE8. But as the [Mozilla documentation](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf#compat-desktop) shows, it is supported IE9. The conditional will be false in IE8, and `<body>` will have a class of no-customize-support.

