### PR TITLE
[Alternate PR] Trac 38021  : Remove Customizer support for IE8

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -740,7 +740,6 @@ final class WP_Customize_Manager {
 		wp_enqueue_script( 'customize-preview' );
 		add_action( 'wp', array( $this, 'customize_preview_override_404_status' ) );
 		add_action( 'wp_head', array( $this, 'customize_preview_base' ) );
-		add_action( 'wp_head', array( $this, 'customize_preview_html5' ) );
 		add_action( 'wp_head', array( $this, 'customize_preview_loading_style' ) );
 		add_action( 'wp_footer', array( $this, 'customize_preview_settings' ), 20 );
 		add_action( 'shutdown', array( $this, 'customize_preview_signature' ), 1000 );
@@ -787,18 +786,10 @@ final class WP_Customize_Manager {
 	 * Print a workaround to handle HTML5 tags in IE < 9.
 	 *
 	 * @since 3.4.0
+	 * @deprecated 4.7.0 Customizer no longer supports IE8, so all supported browsers recognize HTML5.
 	 */
-	public function customize_preview_html5() { ?>
-		<!--[if lt IE 9]>
-		<script type="text/javascript">
-			var e = [ 'abbr', 'article', 'aside', 'audio', 'canvas', 'datalist', 'details',
-				'figure', 'footer', 'header', 'hgroup', 'mark', 'menu', 'meter', 'nav',
-				'output', 'progress', 'section', 'time', 'video' ];
-			for ( var i = 0; i < e.length; i++ ) {
-				document.createElement( e[i] );
-			}
-		</script>
-		<![endif]--><?php
+	public function customize_preview_html5() {
+		_deprecated_function( __FUNCTION__, '4.7.0' );
 	}
 
 	/**

--- a/src/wp-includes/js/customize-selective-refresh.js
+++ b/src/wp-includes/js/customize-selective-refresh.js
@@ -745,11 +745,6 @@ wp.customize.selectiveRefresh = ( function( $, api ) {
 	api.bind( 'preview-ready', function() {
 		var handleSettingChange, watchSettingChange, unwatchSettingChange;
 
-		// Polyfill for IE8 to support the document.head attribute.
-		if ( ! document.head ) {
-			document.head = $( 'head:first' )[0];
-		}
-
 		_.extend( self.data, _customizePartialRefreshExports );
 
 		// Create the partial JS models.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2169,6 +2169,7 @@ function wp_customize_support_script() {
 <?php		endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
+			// The customizer requires postMessage and CORS (if the site is cross domain)
 			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
 		}());
 	</script>

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2158,25 +2158,28 @@ function wp_customize_support_script() {
 	$cross_domain = ( strtolower( $admin_origin[ 'host' ] ) != strtolower( $home_origin[ 'host' ] ) );
 
 	?>
-	<script type="text/javascript">
-		(function() {
-			var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
+	<!--[if lte IE 8]>
+		<script type="text/javascript">
+			document.body.className = document.body.className.replace( /(^|\s)(no-)?customize-support/, '' ).trim() + ' no-customize-support';
+		</script>
+	<![endif]-->
+	<![if gte IE 9]>
+		<script type="text/javascript">
+			(function() {
+				var request, b = document.body, c = 'className', cs = 'customize-support', rcs = new RegExp('(^|\\s+)(no-)?'+cs+'(\\s+|$)');
 
-<?php		if ( $cross_domain ): ?>
-			request = (function(){ var xhr = new XMLHttpRequest(); return ('withCredentials' in xhr); })();
-<?php		else: ?>
-			request = true;
-<?php		endif; ?>
+		<?php	if ( $cross_domain ) : ?>
+				request = (function(){ var xhr = new XMLHttpRequest(); return ('withCredentials' in xhr); })();
+		<?php	else : ?>
+				request = true;
+		<?php	endif; ?>
 
-			b[c] = b[c].replace( rcs, ' ' );
-			// The customizer requires postMessage and CORS (if the site is cross domain)
-			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
-		}());
-	</script>
-
-	<!--[if lte IE 8]><script type="text/javascript">
-		document.body.className = document.body.className.replace( 'customize-support', 'no-customize-support' );
-	</script><![endif]-->
+				b[c] = b[c].replace( rcs, ' ' );
+				// The customizer requires postMessage and CORS (if the site is cross domain)
+				b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
+			}());
+		</script>
+	<![endif]>
 	<?php
 }
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2169,9 +2169,13 @@ function wp_customize_support_script() {
 <?php		endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
-			b[c] += ( window.postMessage && request && Array.prototype.indexOf ? ' ' : ' no-' ) + cs;
+			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
 		}());
 	</script>
+
+	<!--[if lte IE 8]><script type="text/javascript">
+		document.body.className = document.body.className.replace( 'customize-support', 'no-customize-support' );
+	</script><![endif]-->
 	<?php
 }
 


### PR DESCRIPTION
**Request To Review New Pull Request**

Hi @westonruter,
Thanks for [catching](https://github.com/xwp/wordpress-develop/pull/156#discussion_r79984932) the issue with the `no-customize-support` being replaced with `no-no-customize-support` in the other [pull request](https://github.com/xwp/wordpress-develop/pull/156#discussion_r79984932). I opened this new pull request, because the other has a merge conflict after its [first commit](https://github.com/xwp/wordpress-develop/pull/156/commits/0e873bdcab65bd84e7af0b294e5c4433cd708ed0) went into Core.

In the [script that removes IE8 support](https://github.com/xwp/wordpress-develop/compare/trac-38021-ie8?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2161), this PR [removes](https://github.com/xwp/wordpress-develop/compare/trac-38021-ie8?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2163) either `.customize-support` or  `.no-customize-support` from `<body>`, before adding `.no-customize-support`. I don’t think we can be sure which, if any class will appear.

When the admin header bar is present on the front end of the site, `<body>` will [usually have](https://github.com/xwp/wordpress-develop/blob/trac-38021-ie8/src/wp-includes/post-template.php#L711) the `no-customize-support` class before this script runs. So IE8 support would already be removed, based on the conditional comments in these commits.

But this assumes:

* The theme calls [body_class()](https://github.com/xwp/wordpress-develop/blob/trac-38021-ie8/src/wp-includes/post-template.php#L555) in `<body>`
* No change of the `no-customize-support` class in the filter [body_class](https://github.com/xwp/wordpress-develop/blob/trac-38021-ie8/src/wp-includes/post-template.php#L766)


So this commit [removes either class](https://github.com/xwp/wordpress-develop/compare/trac-38021-ie8?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2163): `customize-support` or `no-customize-support`:

```document.body.className = document.body.className.replace( /(^|\s)(no-)?customize-support/, '' ).trim() + ' no-customize-support';```

This seems to be the same approach that the [original script takes](https://github.com/xwp/wordpress-develop/compare/trac-38021-ie8?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2177). Substituting variable values, this would be:
`document.body[ ‘className’ ] = document.body[ ‘className’ ].replace( new RegExp('(^|\\s+)(no-)?customize-support(\\s+|$)’), ‘ ‘ );`

The [original script](https://github.com/xwp/wordpress-develop/compare/trac-38021-ie8?expand=1#diff-c3492b4a8b647a363b5d0de02d8a39c8R2166) is wrapped in the [downlevel conditional](https://msdn.microsoft.com/en-us/library/ms537512(v=vs.85).aspx#dlreveale) `<![if gte IE 9]>`. So it will run on all non-IE browser, and IE9+. I couldn’t find an exact equivalent to an `else` statement in conditional comments.

The new IE8 script is wrapped in a more normal conditional comment, which only IE will recognize. Luckily, non-IE browsers will parse it as a comment, and won’t run its inefficient Regex and string concatenation.

