### PR TITLE
Trac-38162 : Themes - take paged.php out of the template heirarchy.

### DIFF
--- a/src/wp-includes/template-loader.php
+++ b/src/wp-includes/template-loader.php
@@ -60,7 +60,6 @@ if ( defined('WP_USE_THEMES') && WP_USE_THEMES ) :
 	elseif ( is_author()         && $template = get_author_template()         ) :
 	elseif ( is_date()           && $template = get_date_template()           ) :
 	elseif ( is_archive()        && $template = get_archive_template()        ) :
-	elseif ( is_paged()          && $template = get_paged_template()          ) :
 	else :
 		$template = get_index_template();
 	endif;

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -388,13 +388,14 @@ function get_page_template() {
  * The template path is filterable via the {@see 'paged_template'} hook.
  *
  * @since 1.5.0
+ * @deprecated 4.7.0 The paged.php template is no longer part of the heirarchy.
  *
  * @see get_query_template()
  *
- * @return string Full path to paged template file.
+ * @return void
  */
 function get_paged_template() {
-	return get_query_template('paged');
+	_deprecated_function( __FUNCTION__, '4.7.0' );
 }
 
 /**


### PR DESCRIPTION
(Awaiting the Travis build)

Themes: Take paged.php out of the template heirarchy.
Deprecate get_paged_template(), which retreived that template.
Perhaps it should be deleted instead, but it's a public function
And remove the statement that called the function.

Fixes #38162.