### PR TITLE
Trac 38499 : Display checkmark on newly-created pages.

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -585,7 +585,8 @@
 					'type_label': itemTypeLabel,
 					'object': itemObject,
 					'object_id': data.post_id,
-					'url': data.url
+					'url': data.url,
+					'is_new_item': true
 				} );
 
 				// Add new item to menu.

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -850,7 +850,7 @@ final class WP_Customize_Nav_Menus {
 		<script type="text/html" id="tmpl-available-menu-item">
 			<li id="menu-item-tpl-{{ data.id }}" class="menu-item-tpl" data-menu-item-id="{{ data.id }}">
 				<div class="menu-item-bar">
-					<div class="menu-item-handle">
+					<div class="menu-item-handle<# if ( true === data.is_new_item ) { #> item-added<# } #>">
 						<span class="item-type" aria-hidden="true">{{ data.type_label }}</span>
 						<span class="item-title" aria-hidden="true">
 							<span class="menu-item-title<# if ( ! data.title ) { #> no-title<# } #>">{{ data.title || wp.customize.Menus.data.l10n.untitled }}</span>


### PR DESCRIPTION
**Request For Review Here Or On [Trac Ticket](https://core.trac.wordpress.org/ticket/38499)**

Hi @celloexpressions,
If you'd like to review this pull request here, that'd be great. Otherwise, looking at the patch on the [Trac ticket](https://core.trac.wordpress.org/ticket/38499) would be just as good.

This passes the [available-menu-item template](https://core.trac.wordpress.org/ticket/38499#comment:3) a value of `true` for [is_new_item](https://github.com/xwp/wordpress-develop/compare/trac-38499?expand=1#diff-027b34627f17d21422fd5065315a6226R589). The template will then output the class `item-added`, as you [suggested](https://core.trac.wordpress.org/ticket/38499#trac-change-2-1477591722273107).
