### PR TITLE
WP Trac 38672: Custom CSS should work with existing Jetpack custom CSS

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -268,12 +268,12 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 		 *         $css = $post->post_content_filtered;
 		 *     }
 		 *     return $css;
-		 * }
+		 * }, 10, 2 );
 		 * </code>
 		 *
 		 * @since 4.7.0
 		 * @param array  $args {
-		 *     Content post args (unslashed) for wp_update_post()/wp_insert_post().
+		 *     Content post args (unslashed) for `wp_update_post()`/`wp_insert_post()`.
 		 *
 		 *     @type string $post_content          CSS.
 		 *     @type string $post_content_filtered Pre-processed CSS. Normally empty string.

--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -16,7 +16,7 @@
  *
  * @see WP_Customize_Setting
  */
-class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
+final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 
 	/**
 	 * The setting type.
@@ -127,10 +127,12 @@ class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	 *
 	 * @since 4.7.0
 	 * @access public
+	 * @see WP_Customize_Setting::value()
 	 *
 	 * @return string
 	 */
 	public function value() {
+		$id_base = $this->id_data['base'];
 		if ( $this->is_previewed && null !== $this->post_value( null ) ) {
 			return $this->post_value();
 		}
@@ -142,6 +144,10 @@ class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 		if ( empty( $value ) ) {
 			$value = $this->default;
 		}
+
+		/** This filter is documented in wp-includes/class-wp-customize-setting.php */
+		$value = apply_filters( "customize_value_{$id_base}", $value, $this );
+
 		return $value;
 	}
 
@@ -236,13 +242,56 @@ class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	 * @return int|false The post ID or false if the value could not be saved.
 	 */
 	public function update( $css ) {
+		$setting = $this;
+
+		if ( empty( $css ) ) {
+			$css = '';
+		}
 
 		$args = array(
-			'post_content' => $css ? $css : '',
-			'post_title' => $this->stylesheet,
-			'post_name' => sanitize_title( $this->stylesheet ),
-			'post_type' => 'custom_css',
-			'post_status' => 'publish',
+			'post_content' => $css,
+			'post_content_filtered' => '',
+		);
+
+		/**
+		 * Filters the `post_content` and `post_content_filtered` args for a `custom_css` post being updated.
+		 *
+		 * This filter can be used by plugin that offer CSS pre-processors, to store the original
+		 * pre-processed CSS in `post_content_filtered` and then store processed CSS in `post_content`.
+		 * When used in this way, the `post_content_filtered` should be supplied as the setting value
+		 * instead of `post_content` via a the `customize_value_custom_css` filter, for example:
+		 *
+		 * <code>
+		 * add_filter( 'customize_value_custom_css', function( $value, $setting ) {
+		 *     $post = wp_get_custom_css_post( $setting->stylesheet );
+		 *     if ( $post && ! empty( $post->post_content_filtered ) ) {
+		 *         $css = $post->post_content_filtered;
+		 *     }
+		 *     return $css;
+		 * }
+		 * </code>
+		 *
+		 * @since 4.7.0
+		 * @param array  $args {
+		 *     Content post args (unslashed) for wp_update_post()/wp_insert_post().
+		 *
+		 *     @type string $post_content          CSS.
+		 *     @type string $post_content_filtered Pre-processed CSS. Normally empty string.
+		 * }
+		 * @param string                          $css     Original CSS being updated.
+		 * @param WP_Customize_Custom_CSS_Setting $setting Custom CSS Setting.
+		 */
+		$args = apply_filters( 'customize_update_custom_css_post_content_args', $args, $css, $setting );
+		$args = wp_array_slice_assoc( $args, array( 'post_content', 'post_content_filtered' ) );
+
+		$args = array_merge(
+			$args,
+			array(
+				'post_title' => $this->stylesheet,
+				'post_name' => sanitize_title( $this->stylesheet ),
+				'post_type' => 'custom_css',
+				'post_status' => 'publish',
+			)
 		);
 
 		// Update post if it already exists, otherwise create a new one.

--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -16,7 +16,7 @@
  *
  * @see WP_Customize_Setting
  */
-final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
+class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 
 	/**
 	 * The setting type.
@@ -100,10 +100,13 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	}
 
 	/**
-	 * Filter wp_get_custom_css for applying customized value to return value.
+	 * Filter `wp_get_custom_css` for applying the customized value.
+	 *
+	 * This is used in the preview when `wp_get_custom_css()` is called for rendering the styles.
 	 *
 	 * @since 4.7.0
 	 * @access private
+	 * @see wp_get_custom_css()
 	 *
 	 * @param string $css        Original CSS.
 	 * @param string $stylesheet Current stylesheet.
@@ -120,7 +123,7 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	}
 
 	/**
-	 * Fetch the value of the setting.
+	 * Fetch the value of the setting. Will return the previewed value when `preview()` is called.
 	 *
 	 * @since 4.7.0
 	 * @access public
@@ -128,7 +131,14 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 	 * @return string
 	 */
 	public function value() {
-		$value = wp_get_custom_css( $this->stylesheet );
+		if ( $this->is_previewed && null !== $this->post_value( null ) ) {
+			return $this->post_value();
+		}
+		$value = '';
+		$post = wp_get_custom_css_post( $this->stylesheet );
+		if ( $post ) {
+			$value = $post->post_content;
+		}
 		if ( empty( $value ) ) {
 			$value = $this->default;
 		}

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1500,8 +1500,12 @@ function _custom_background_cb() {
 		$color = false;
 	}
 
-	if ( ! $background && ! $color )
+	if ( ! $background && ! $color ) {
+		if ( is_customize_preview() ) {
+			echo '<style type="text/css" id="custom-background-css"></style>';
+		}
 		return;
+	}
 
 	$style = $color ? "background-color: #$color;" : '';
 
@@ -1621,7 +1625,7 @@ function wp_get_custom_css_post( $stylesheet = '' ) {
 }
 
 /**
- * Fetch the saved Custom CSS content.
+ * Fetch the saved Custom CSS content for rendering.
  *
  * @since 4.7.0
  * @access public


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/38672
Demo plugin that makes use of patch: https://github.com/xwp/wp-custom-scss-demo

 Customize: Improve extensibility of Custom CSS
* Eliminate `final`-ity from `WP_Customize_Custom_CSS_Setting` class to allow extensibility.
* Eliminate use of `wp_get_custom_css()` when getting the setting value. Use the underlying `post_value` directly when `is_previewed`.
* Make clear that `wp_get_custom_css()` is specifically for obtaining the value to render/display.
* Move anonymous functions handing JS previewing for `custom_logo`, `custom_css`, and `background` into named functions on the `wp.customize.settingPreviewHandlers` to allow plugins to override/extend.
* Update `_custom_background_cb` to always print a `style` tag in the customizer preview.
* Update `background` preview logic to replace existing `style` element instead of appending a new `style` to the `head`, and thus unexpectedly overriding any Custom CSS in the preview.