### PR TITLE
#38948 - Make sure Sortables is initialized after the section has been expanded.

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1045,13 +1045,21 @@
 					}
 				} );
 
-				if ( 'resolved' !== section.deferred.initSortables.state() ) {
-					wpNavMenu.initSortables(); // Depends on menu-to-edit ID being set above.
-					section.deferred.initSortables.resolve( wpNavMenu.menuList ); // Now MenuControl can extend the sortable.
+				// Make sure Sortables is initialized after the section has been expanded to prevent `offset` issues.
+				api.state( 'expandedSection' ).bind( $.proxy( function( newSection ) {
+					var section = this;
 
-					// @todo Note that wp.customize.reflowPaneContents() is debounced, so this immediate change will show a slight flicker while priorities get updated.
-					api.control( 'nav_menu[' + String( section.params.menu_id ) + ']' ).reflowMenuItems();
-				}
+					if ( ! newSection || newSection.id !== section.id ) {
+						return false;
+					}
+					if ( 'resolved' !== section.deferred.initSortables.state() ) {
+						wpNavMenu.initSortables(); // Depends on menu-to-edit ID being set above.
+						section.deferred.initSortables.resolve( wpNavMenu.menuList ); // Now MenuControl can extend the sortable.
+
+						// @todo Note that wp.customize.reflowPaneContents() is debounced, so this immediate change will show a slight flicker while priorities get updated.
+						api.control( 'nav_menu[' + String( section.params.menu_id ) + ']' ).reflowMenuItems();
+					}
+				}, section ) );
 			}
 			api.Section.prototype.onChangeExpanded.call( section, expanded, args );
 		}

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1029,7 +1029,7 @@
 		},
 
 		onChangeExpanded: function( expanded, args ) {
-			var section = this;
+			var section = this, completeCallback;
 
 			if ( expanded ) {
 				wpNavMenu.menuList = section.contentContainer;
@@ -1046,12 +1046,10 @@
 				} );
 
 				// Make sure Sortables is initialized after the section has been expanded to prevent `offset` issues.
-				api.state( 'expandedSection' ).bind( $.proxy( function( newSection ) {
-					var section = this;
-
-					if ( ! newSection || newSection.id !== section.id ) {
-						return false;
-					}
+				if ( args.completeCallback ) {
+					completeCallback = args.completeCallback;
+				}
+				args.completeCallback = function() {
 					if ( 'resolved' !== section.deferred.initSortables.state() ) {
 						wpNavMenu.initSortables(); // Depends on menu-to-edit ID being set above.
 						section.deferred.initSortables.resolve( wpNavMenu.menuList ); // Now MenuControl can extend the sortable.
@@ -1059,7 +1057,10 @@
 						// @todo Note that wp.customize.reflowPaneContents() is debounced, so this immediate change will show a slight flicker while priorities get updated.
 						api.control( 'nav_menu[' + String( section.params.menu_id ) + ']' ).reflowMenuItems();
 					}
-				}, section ) );
+					if ( _.isFunction( completeCallback ) ) {
+						completeCallback();
+					}
+				};
 			}
 			api.Section.prototype.onChangeExpanded.call( section, expanded, args );
 		}


### PR DESCRIPTION
Make sure Sortables is initialized after the section has been expanded to prevent `offset` issues.