### PR TITLE
36163 Allow empty array to allow not classes added.

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -70,10 +70,10 @@ class Walker_Nav_Menu extends Walker {
 		 */
 
 		$classes = array( 'sub-menu' );
-		$classes = apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth );
-		$class_names = join( ' ', $classes );
+		$class_names = join( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
-		$output .= "{$n}{$indent}<ul class='" . esc_attr( $class_names ) . "'>{$n}";
+		$output .= "{$n}{$indent}<ul $class_names>{$n}";
 	}
 
 	/**


### PR DESCRIPTION
If class names are returned as an empty array, let's not append `class=` to the `ul` element.