### PR TITLE
Support YouTube Embed URLs

### DIFF
--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -145,7 +145,7 @@ wp.mediaWidgets = ( function( $ ) {
 					 * @returns {void}
 					 */
 					fetch: function() {
-						var embedLinkView = this, fetchSuccess, matches, fileExt, urlParser; // eslint-disable-line consistent-this
+						var embedLinkView = this, fetchSuccess, matches, fileExt, urlParser, url, re, youTubeEmbedMatch; // eslint-disable-line consistent-this
 
 						if ( embedLinkView.dfd && 'pending' === embedLinkView.dfd.state() ) {
 							embedLinkView.dfd.abort();
@@ -190,10 +190,20 @@ wp.mediaWidgets = ( function( $ ) {
 							return;
 						}
 
+						// Support YouTube embed links.
+						url = embedLinkView.model.get( 'url' );
+						re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
+						youTubeEmbedMatch = re.exec( url );
+						if ( youTubeEmbedMatch ) {
+							url = 'https://www.youtube.com/watch?v=' + youTubeEmbedMatch[ 1 ];
+							// silently change url to proper oembed-able version.
+							embedLinkView.model.attributes.url = url;
+						}
+
 						embedLinkView.dfd = $.ajax({
 							url: wp.media.view.settings.oEmbedProxyUrl,
 							data: {
-								url: embedLinkView.model.get( 'url' ),
+								url: url,
 								maxwidth: embedLinkView.model.get( 'width' ),
 								maxheight: embedLinkView.model.get( 'height' ),
 								_wpnonce: wp.media.view.settings.nonce.wpRestApi,

--- a/src/wp-includes/js/media-views.js
+++ b/src/wp-includes/js/media-views.js
@@ -4509,7 +4509,6 @@ var Embed = wp.media.View.extend({
 			controller: this.controller,
 			model:      this.model.props
 		}).render();
-
 		this.views.set([ this.url ]);
 		this.refresh();
 		this.listenTo( this.model, 'change:type', this.refresh );
@@ -4624,14 +4623,22 @@ EmbedLink = wp.media.view.Settings.extend({
 	}, wp.media.controller.Embed.sensitivity ),
 
 	fetch: function() {
+		var url = this.model.get( 'url' );
 
 		// check if they haven't typed in 500 ms
-		if ( $('#embed-url-field').val() !== this.model.get('url') ) {
+		if ( $('#embed-url-field').val() !== url ) {
 			return;
 		}
 
 		if ( this.dfd && 'pending' === this.dfd.state() ) {
 			this.dfd.abort();
+		}
+
+		// Support YouTube embed urls, since they work once in the editor.
+		var re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
+		var youTubeEmbedMatch = re.exec( url );
+		if ( youTubeEmbedMatch ) {
+			url = 'https://www.youtube.com/watch?v=' + youTubeEmbedMatch[ 1 ];
 		}
 
 		this.dfd = $.ajax({

--- a/src/wp-includes/js/media-views.js
+++ b/src/wp-includes/js/media-views.js
@@ -4509,6 +4509,7 @@ var Embed = wp.media.View.extend({
 			controller: this.controller,
 			model:      this.model.props
 		}).render();
+
 		this.views.set([ this.url ]);
 		this.refresh();
 		this.listenTo( this.model, 'change:type', this.refresh );
@@ -4623,7 +4624,7 @@ EmbedLink = wp.media.view.Settings.extend({
 	}, wp.media.controller.Embed.sensitivity ),
 
 	fetch: function() {
-		var url = this.model.get( 'url' );
+		var url = this.model.get( 'url' ), re, youTubeEmbedMatch;
 
 		// check if they haven't typed in 500 ms
 		if ( $('#embed-url-field').val() !== url ) {
@@ -4635,8 +4636,8 @@ EmbedLink = wp.media.view.Settings.extend({
 		}
 
 		// Support YouTube embed urls, since they work once in the editor.
-		var re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
-		var youTubeEmbedMatch = re.exec( url );
+		re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
+		youTubeEmbedMatch = re.exec( url );
 		if ( youTubeEmbedMatch ) {
 			url = 'https://www.youtube.com/watch?v=' + youTubeEmbedMatch[ 1 ];
 		}
@@ -4644,7 +4645,7 @@ EmbedLink = wp.media.view.Settings.extend({
 		this.dfd = $.ajax({
 			url: wp.media.view.settings.oEmbedProxyUrl,
 			data: {
-				url: this.model.get( 'url' ),
+				url: url,
 				maxwidth: this.model.get( 'width' ),
 				maxheight: this.model.get( 'height' ),
 				_wpnonce: wp.media.view.settings.nonce.wpRestApi

--- a/src/wp-includes/js/media/views/embed/link.js
+++ b/src/wp-includes/js/media/views/embed/link.js
@@ -35,7 +35,7 @@ EmbedLink = wp.media.view.Settings.extend({
 	}, wp.media.controller.Embed.sensitivity ),
 
 	fetch: function() {
-		var url = this.model.get( 'url' );
+		var url = this.model.get( 'url' ), re, youTubeEmbedMatch;
 
 		// check if they haven't typed in 500 ms
 		if ( $('#embed-url-field').val() !== url ) {
@@ -47,8 +47,8 @@ EmbedLink = wp.media.view.Settings.extend({
 		}
 
 		// Support YouTube embed urls, since they work once in the editor.
-		var re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
-		var youTubeEmbedMatch = re.exec( url );
+		re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
+		youTubeEmbedMatch = re.exec( url );
 		if ( youTubeEmbedMatch ) {
 			url = 'https://www.youtube.com/watch?v=' + youTubeEmbedMatch[ 1 ];
 		}
@@ -56,7 +56,7 @@ EmbedLink = wp.media.view.Settings.extend({
 		this.dfd = $.ajax({
 			url: wp.media.view.settings.oEmbedProxyUrl,
 			data: {
-				url: this.model.get( 'url' ),
+				url: url,
 				maxwidth: this.model.get( 'width' ),
 				maxheight: this.model.get( 'height' ),
 				_wpnonce: wp.media.view.settings.nonce.wpRestApi

--- a/src/wp-includes/js/media/views/embed/link.js
+++ b/src/wp-includes/js/media/views/embed/link.js
@@ -35,14 +35,22 @@ EmbedLink = wp.media.view.Settings.extend({
 	}, wp.media.controller.Embed.sensitivity ),
 
 	fetch: function() {
+		var url = this.model.get( 'url' );
 
 		// check if they haven't typed in 500 ms
-		if ( $('#embed-url-field').val() !== this.model.get('url') ) {
+		if ( $('#embed-url-field').val() !== url ) {
 			return;
 		}
 
 		if ( this.dfd && 'pending' === this.dfd.state() ) {
 			this.dfd.abort();
+		}
+
+		// Support YouTube embed urls, since they work once in the editor.
+		var re = /https?:\/\/www\.youtube\.com\/embed\/([^/]+)/;
+		var youTubeEmbedMatch = re.exec( url );
+		if ( youTubeEmbedMatch ) {
+			url = 'https://www.youtube.com/watch?v=' + youTubeEmbedMatch[ 1 ];
 		}
 
 		this.dfd = $.ajax({


### PR DESCRIPTION
This PR adds support for YouTube embed URL's in both the media modal within the editor, and the Video Widget.

To test, use a YouTube embed URL in both places `https://www.youtube.com/embed/ea2WoUtbzuw` and verify the oembed proxy preview is shown properly, and the URL works in both the editor and the video widget.