### PR TITLE
#41274: Expose link input in widget

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -152,10 +152,6 @@
 	border: 1px solid #f00;
 }
 
-.media-widget-extra {
-	text-align: left;
-}
-
 .media-widget-image-link {
 	margin: 1em 0;
 }

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -152,6 +152,14 @@
 	border: 1px solid #f00;
 }
 
+.media-widget-extra {
+	text-align: left;
+}
+
+.media-widget-image-link {
+	margin: 1em 0;
+}
+
 /* Widget Dragging Helpers */
 .widget.ui-draggable-dragging {
 	min-width: 100%;

--- a/src/wp-admin/js/widgets/media-image-widget.js
+++ b/src/wp-admin/js/widgets/media-image-widget.js
@@ -37,13 +37,13 @@
 
 			previewContainer = control.$el.find( '.media-widget-preview' );
 			previewTemplate = wp.template( 'wp-media-widget-image-preview' );
-			previewContainer.html( previewTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
+			previewContainer.html( previewTemplate( control.previewTemplateProps.toJSON() ) );
 
 			linkInput = control.$el.find( '.link' );
 			if ( ! linkInput.is( document.activeElement ) ) {
 				fieldsContainer = control.$el.find( '.media-widget-fields' );
 				fieldsTemplate = wp.template( 'wp-media-widget-image-fields' );
-				fieldsContainer.html( fieldsTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
+				fieldsContainer.html( fieldsTemplate( control.previewTemplateProps.toJSON() ) );
 			}
 		},
 
@@ -71,11 +71,14 @@
 			mediaFrame.$el.addClass( 'media-widget' );
 
 			updateCallback = function() {
-				var mediaProps;
+				var mediaProps, linkType;
 
 				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
 				mediaProps = mediaFrame.state().attributes.image.toJSON();
+				linkType = mediaProps.link;
+				mediaProps.link = mediaProps.linkUrl;
 				control.selectedAttachment.set( mediaProps );
+				control.displaySettings.set( 'link', linkType );
 
 				control.model.set( _.extend(
 					control.mapMediaToModelProps( mediaProps ),

--- a/src/wp-admin/js/widgets/media-image-widget.js
+++ b/src/wp-admin/js/widgets/media-image-widget.js
@@ -30,7 +30,7 @@
 		 * @returns {void}
 		 */
 		renderPreview: function renderPreview() {
-			var control = this, previewContainer, previewTemplate, extraContainer, extraTemplate, linkInput;
+			var control = this, previewContainer, previewTemplate, fieldsContainer, fieldsTemplate, linkInput;
 			if ( ! control.model.get( 'attachment_id' ) && ! control.model.get( 'url' ) ) {
 				return;
 			}
@@ -41,9 +41,9 @@
 
 			linkInput = control.$el.find( '.link' );
 			if ( ! linkInput.is( document.activeElement ) ) {
-				extraContainer = control.$el.find( '.media-widget-extra' );
-				extraTemplate = wp.template( 'wp-media-widget-image-extra' );
-				extraContainer.html( extraTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
+				fieldsContainer = control.$el.find( '.media-widget-fields' );
+				fieldsTemplate = wp.template( 'wp-media-widget-image-fields' );
+				fieldsContainer.html( fieldsTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
 			}
 		},
 
@@ -137,12 +137,12 @@
 		 * @returns {Object} Preview template props.
 		 */
 		mapModelToPreviewTemplateProps: function mapModelToPreviewTemplateProps() {
-			var control = this, mediaFrameProps, url;
+			var control = this, previewTemplateProps, url;
 			url = control.model.get( 'url' );
-			mediaFrameProps = component.MediaWidgetControl.prototype.mapModelToPreviewTemplateProps.call( control );
-			mediaFrameProps.currentFilename = url ? url.replace( /\?.*$/, '' ).replace( /^.+\//, '' ) : '';
-			mediaFrameProps.link_url = control.model.get( 'link_url' );
-			return mediaFrameProps;
+			previewTemplateProps = component.MediaWidgetControl.prototype.mapModelToPreviewTemplateProps.call( control );
+			previewTemplateProps.currentFilename = url ? url.replace( /\?.*$/, '' ).replace( /^.+\//, '' ) : '';
+			previewTemplateProps.link_url = control.model.get( 'link_url' );
+			return previewTemplateProps;
 		}
 	});
 

--- a/src/wp-admin/js/widgets/media-image-widget.js
+++ b/src/wp-admin/js/widgets/media-image-widget.js
@@ -30,7 +30,7 @@
 		 * @returns {void}
 		 */
 		renderPreview: function renderPreview() {
-			var control = this, previewContainer, previewTemplate;
+			var control = this, previewContainer, previewTemplate, extraContainer, extraTemplate, linkInput;
 			if ( ! control.model.get( 'attachment_id' ) && ! control.model.get( 'url' ) ) {
 				return;
 			}
@@ -38,6 +38,13 @@
 			previewContainer = control.$el.find( '.media-widget-preview' );
 			previewTemplate = wp.template( 'wp-media-widget-image-preview' );
 			previewContainer.html( previewTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
+
+			linkInput = control.$el.find( '.link' );
+			if ( ! linkInput.is( document.activeElement ) ) {
+				extraContainer = control.$el.find( '.media-widget-extra' );
+				extraTemplate = wp.template( 'wp-media-widget-image-extra' );
+				extraContainer.html( extraTemplate( _.extend( control.previewTemplateProps.toJSON() ) ) );
+			}
 		},
 
 		/**
@@ -134,6 +141,7 @@
 			url = control.model.get( 'url' );
 			mediaFrameProps = component.MediaWidgetControl.prototype.mapModelToPreviewTemplateProps.call( control );
 			mediaFrameProps.currentFilename = url ? url.replace( /\?.*$/, '' ).replace( /^.+\//, '' ) : '';
+			mediaFrameProps.link_url = control.model.get( 'link_url' );
 			return mediaFrameProps;
 		}
 	});

--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -514,7 +514,7 @@ wp.mediaWidgets = ( function( $ ) {
 			});
 
 			// Update link_url attribute.
-			control.$el.on( 'input change', '.link', function updateExtra() {
+			control.$el.on( 'input change', '.link', function updateLinkUrl() {
 				var linkUrl = $.trim( $( this ).val() ), linkType = 'custom';
 				if ( control.selectedAttachment.get( 'linkUrl' ) === linkUrl || control.selectedAttachment.get( 'link' ) === linkUrl ) {
 					linkType = 'post';

--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -515,10 +515,22 @@ wp.mediaWidgets = ( function( $ ) {
 
 			// Update link_url attribute.
 			control.$el.on( 'input change', '.link', function updateExtra() {
-				var linkUrl = $.trim( $( this ).val() );
+				var linkUrl = $.trim( $( this ).val() ), linkType = 'custom';
+				if ( control.selectedAttachment.get( 'linkUrl' ) === linkUrl || control.selectedAttachment.get( 'link' ) === linkUrl ) {
+					linkType = 'post';
+				} else if ( control.selectedAttachment.get( 'url' ) === linkUrl ) {
+					linkType = 'file';
+				}
 				control.model.set( {
-					link_url: linkUrl
-				} );
+					link_url: linkUrl,
+					link_type: linkType
+				});
+
+				// Update display settings for the next time the user opens to select from the media library.
+				control.displaySettings.set( {
+					link: linkType,
+					linkUrl: linkUrl
+				});
 			});
 
 			/*
@@ -827,7 +839,7 @@ wp.mediaWidgets = ( function( $ ) {
 			}
 
 			if ( 'post' === mediaFrameProps.link ) {
-				modelProps.link_url = mediaFrameProps.postUrl;
+				modelProps.link_url = mediaFrameProps.postUrl || mediaFrameProps.linkUrl;
 			} else if ( 'file' === mediaFrameProps.link ) {
 				modelProps.link_url = mediaFrameProps.url;
 			}

--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -513,16 +513,12 @@ wp.mediaWidgets = ( function( $ ) {
 				});
 			});
 
-			// Update extra attributes.
-			control.$el.on( 'input change', '.extra', function updateExtra() {
-				var newValues = {}, attr;
-				attr = $( this ).attr( 'data-attr' );
-				newValues[ attr ] = $.trim( $( this ).val() );
-
-				if ( attr === 'link_url' ) {
-					newValues.link_type = 'custom';
-				}
-				control.model.set( newValues );
+			// Update link_url attribute.
+			control.$el.on( 'input change', '.link', function updateExtra() {
+				var linkUrl = $.trim( $( this ).val() );
+				control.model.set( {
+					link_url: linkUrl
+				} );
 			});
 
 			/*

--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -515,8 +515,13 @@ wp.mediaWidgets = ( function( $ ) {
 
 			// Update extra attributes.
 			control.$el.on( 'input change', '.extra', function updateExtra() {
-				var newValues = {};
-				newValues[ $( this ).attr( 'data-attr' ) ] = $.trim( $( this ).val() );
+				var newValues = {}, attr;
+				attr = $( this ).attr( 'data-attr' );
+				newValues[ attr ] = $.trim( $( this ).val() );
+
+				if ( attr === 'link_url' ) {
+					newValues.link_type = 'custom';
+				}
 				control.model.set( newValues );
 			});
 

--- a/src/wp-admin/js/widgets/media-widgets.js
+++ b/src/wp-admin/js/widgets/media-widgets.js
@@ -513,6 +513,13 @@ wp.mediaWidgets = ( function( $ ) {
 				});
 			});
 
+			// Update extra attributes.
+			control.$el.on( 'input change', '.extra', function updateExtra() {
+				var newValues = {};
+				newValues[ $( this ).attr( 'data-attr' ) ] = $.trim( $( this ).val() );
+				control.model.set( newValues );
+			});
+
 			/*
 			 * Copy current display settings from the widget model to serve as basis
 			 * of customized display settings for the current media frame session.

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -312,7 +312,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			<# if ( data.url ) { #>
 			<p class="media-widget-image-link">
 				<label for="{{ elementIdPrefix }}linkUrl"><?php esc_html_e( 'Link to:' ); ?></label>
-				<input id="{{ elementIdPrefix }}linkUrl" type="text" class="widefat link extra" value="{{ data.link_url }}" placeholder="http://">
+				<input id="{{ elementIdPrefix }}linkUrl" type="url" class="widefat link" value="{{ data.link_url }}" placeholder="http://">
 			</p>
 			<# } #>
 		</script>

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -307,12 +307,12 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 		parent::render_control_template_scripts();
 
 		?>
-		<script type="text/html" id="tmpl-wp-media-widget-image-extra">
+		<script type="text/html" id="tmpl-wp-media-widget-image-fields">
 			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_'; #>
 			<# if ( data.url ) { #>
 			<p class="media-widget-image-link">
 				<label for="{{ elementIdPrefix }}linkUrl"><?php esc_html_e( 'Link to:' ); ?></label>
-				<input id="{{ elementIdPrefix }}linkUrl" type="text" class="widefat link extra" value="{{ data.link_url }}" placeholder="http://" data-attr="link_url">
+				<input id="{{ elementIdPrefix }}linkUrl" type="text" class="widefat link extra" value="{{ data.link_url }}" placeholder="http://">
 			</p>
 			<# } #>
 		</script>

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -95,7 +95,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 					'default' => 'none',
 					'media_prop' => 'link',
 					'description' => __( 'Link To' ),
-					'should_preview_update' => false,
+					'should_preview_update' => true,
 				),
 				'link_url' => array(
 					'type' => 'string',
@@ -103,7 +103,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 					'format' => 'uri',
 					'media_prop' => 'linkUrl',
 					'description' => __( 'URL' ),
-					'should_preview_update' => false,
+					'should_preview_update' => true,
 				),
 				'image_classes' => array(
 					'type' => 'string',

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -307,10 +307,17 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 		parent::render_control_template_scripts();
 
 		?>
+		<script type="text/html" id="tmpl-wp-media-widget-image-extra">
+			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_'; #>
+			<# if ( data.url ) { #>
+			<p class="media-widget-image-link">
+				<label for="{{ elementIdPrefix }}linkUrl"><?php esc_html_e( 'Link to:' ); ?></label>
+				<input id="{{ elementIdPrefix }}linkUrl" type="text" class="widefat link extra" value="{{ data.link_url }}" placeholder="http://" data-attr="link_url">
+			</p>
+			<# } #>
+		</script>
 		<script type="text/html" id="tmpl-wp-media-widget-image-preview">
-			<#
-			var describedById = 'describedBy-' + String( Math.random() );
-			#>
+			<# var describedById = 'describedBy-' + String( Math.random() ); #>
 			<# if ( data.error && 'missing_attachment' === data.error ) { #>
 				<div class="notice notice-error notice-alt notice-missing-attachment">
 					<p><?php echo $this->l10n['missing_attachment']; ?></p>

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -404,7 +404,7 @@ abstract class WP_Widget_Media extends WP_Widget {
 					<?php echo esc_html( $this->l10n['add_media'] ); ?>
 				</button>
 			</p>
-			<div class="media-widget-extra">
+			<div class="media-widget-fields">
 			</div>
 		</script>
 		<?php

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -404,6 +404,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 					<?php echo esc_html( $this->l10n['add_media'] ); ?>
 				</button>
 			</p>
+			<div class="media-widget-extra">
+			</div>
 		</script>
 		<?php
 	}


### PR DESCRIPTION
This branch explores a design that displays the `link_url` input form for the image widget in the widget itself to make it more discoverable.

See mockups: https://cloudup.com/cTX3XurZQBJ