### PR TITLE
Trac 39896: Trashing/reverting changesets and introduce OverlayNotification

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1134,6 +1134,42 @@ p.customize-section-description {
 	margin-top: 1px;
 }
 
+@-webkit-keyframes customize-fade-in {
+	0%   { opacity: 0; }
+	100% { opacity: 1; }
+}
+
+@keyframes customize-fade-in {
+	0%   { opacity: 0; }
+	100% { opacity: 1; }
+}
+
+#customize-controls .notice.notification-overlay,
+#customize-controls #customize-notifications-area .notice.notification-overlay {
+	margin: 0;
+}
+
+#customize-controls .customize-control-notifications-container.has-overlay-notifications {
+	-webkit-animation: customize-fade-in 0.5s;
+	animation: customize-fade-in 0.5s;
+	z-index: 30;
+}
+
+/* Note: Styles for this are also defined in themes.css */
+#customize-controls #customize-notifications-area .notice.notification-overlay .notification-message {
+	clear: both;
+	color: #191e23;
+	font-size: 18px;
+	font-style: normal;
+	margin: 0;
+	padding: 2em 0;
+	text-align: center;
+	width: 100%;
+	display: block;
+	top: 50%;
+	position: relative;
+}
+
 /* Style for custom settings */
 
 /**
@@ -1557,40 +1593,6 @@ p.customize-section-description {
 /**
  * Themes
  */
-
-@-webkit-keyframes customize-reload {
-	0%   { opacity: 0; }
-	100% { opacity: 1; }
-}
-
-@keyframes customize-reload {
-	0%   { opacity: 0; }
-	100% { opacity: 1; }
-}
-
-.wp-customizer .customize-loading #customize-themes-loading-container {
-	display: block;
-	-webkit-animation: customize-reload .5s; /* Can't use `transition` because `display` changes here. */
-	animation: customize-reload .5s;
-}
-
-.customize-loading #customize-themes-loading-container span {
-	clear: both;
-	color: #191e23;
-	font-size: 18px;
-	font-style: normal;
-	margin: 0;
-	padding: 2em 0;
-	text-align: center;
-	width: 100%;
-	display: block;
-	top: 50%;
-	position: relative;
-}
-
-.customize-loading #customize-themes-loading-container .customize-loading-text {
-	display: none;
-}
 
 #customize-theme-controls .control-panel-themes {
 	border-bottom: none;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1164,6 +1164,7 @@ p.customize-section-description {
 #customize-controls .notice.notification-overlay,
 #customize-controls #customize-notifications-area .notice.notification-overlay {
 	margin: 0;
+	border-left: 0; /* @todo Appropriate styles could be added for notice-error, notice-warning, notice-success, etc */
 }
 
 #customize-controls .customize-control-notifications-container.has-overlay-notifications {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -29,11 +29,13 @@ body {
 	margin-top: 9px;
 }
 
+body:not(.ready) #customize-save-button-wrapper .save {
+	visibility: hidden;
+}
 #customize-save-button-wrapper .save {
 	float: left;
 	border-radius: 3px;
 	box-shadow: none; /* @todo Adjust box shadow based on the disable states of paired button. */
-	display: none; /* Shown when ready. */
 	margin-top: 0;
 }
 #customize-save-button-wrapper .save.has-next-sibling {
@@ -106,10 +108,15 @@ body.outer-section-open .wp-full-overlay.expanded .wp-full-overlay-main {
 	font-size: 14px;
 	width: 30px;
 	float: left;
-	display: none; /* Shown when ready. */
 	-webkit-transform: none;
 	transform: none;
 	margin-top: 0;
+}
+
+body:not(.ready) #publish-settings,
+body.trashing #customize-save-button-wrapper .save,
+body.trashing #publish-settings {
+	display: none;
 }
 
 #customize-header-actions .spinner {
@@ -117,7 +124,8 @@ body.outer-section-open .wp-full-overlay.expanded .wp-full-overlay-main {
 	margin-right: 4px;
 }
 
-.saving #customize-header-actions .spinner {
+.saving #customize-header-actions .spinner,
+.trashing #customize-header-actions .spinner {
 	visibility: visible;
 }
 
@@ -1673,8 +1681,6 @@ p.customize-section-description {
 	transition: .18s bottom ease-in-out;
 }
 
-.in-themes-panel:not(.animating) #customize-header-actions .save,
-.in-themes-panel:not(.animating) #customize-header-actions #publish-settings,
 .in-themes-panel:not(.animating) #customize-header-actions .spinner,
 .in-themes-panel:not(.animating) #customize-header-actions .customize-controls-preview-toggle,
 .in-themes-panel:not(.animating) #customize-preview,

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -155,6 +155,23 @@ body.trashing #publish-settings {
 	padding-right: 12px;
 }
 
+#customize-control-trash_changeset {
+	margin-top: 20px;
+}
+#customize-control-trash_changeset button {
+	position: relative;
+	padding-left: 24px;
+	display: inline-block;
+}
+#customize-control-trash_changeset button:before {
+	content: "\f182";
+	font: normal 22px dashicons;
+	text-decoration: none;
+	position: absolute;
+	left: 0;
+	top: -2px;
+}
+
 #customize-controls .date-input:invalid {
 	border-color: red;
 }

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1707,8 +1707,7 @@ body.full-overlay-active {
 }
 
 #customize-container,
-#customize-themes-loading-container {
-	display: none;
+#customize-controls .notice.notification-overlay {
 	background: #eee;
 	z-index: 500000;
 	position: fixed;
@@ -1719,10 +1718,12 @@ body.full-overlay-active {
 	right: 0;
 	height: 100%;
 }
+#customize-container {
+	display: none;
+}
 
 /* Make the Customizer and Theme installer overlays the only available content. */
 #customize-container,
-#customize-themes-loading-container,
 .theme-install-overlay {
 	visibility: visible;
 }
@@ -1827,7 +1828,7 @@ body.full-overlay-active {
 
 #customize-preview.wp-full-overlay-main:before,
 .customize-loading #customize-container:before,
-.customize-loading #customize-themes-loading-container:before,
+#customize-controls .notice.notification-overlay.notification-loading:before,
 .theme-install-overlay .wp-full-overlay-main:before {
 	content: "";
 	display: block;
@@ -1865,7 +1866,7 @@ body.full-overlay-active {
 
 	#customize-preview.wp-full-overlay-main:before,
 	.customize-loading #customize-container:before,
-	.customize-loading #customize-themes-loading-container:before,
+	#customize-controls .notice.notification-overlay.notification-loading:before,
 	.theme-install-overlay .wp-full-overlay-main:before {
 		background-image: url(../images/spinner-2x.gif);
 	}

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -2925,7 +2925,7 @@
 		 * @returns {jQuery.promise} Promise.
 		 */
 		loadThemePreview: function( themeId ) {
-			var deferred = $.Deferred(), onceProcessingComplete, overlay, urlParser, queryParams;
+			var deferred = $.Deferred(), onceProcessingComplete, urlParser, queryParams;
 
 			urlParser = document.createElement( 'a' );
 			urlParser.href = location.href;

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6238,6 +6238,7 @@
 		'saved',
 		'autosaved',
 		'saving',
+		'trashing',
 		'activated',
 		'processing',
 		'paneVisible',
@@ -6308,6 +6309,9 @@
 				if ( ! api.state( 'activated' ).get() ) {
 					return false;
 				}
+				if ( api.state( 'trashing' ).get() || 'trash' === api.state( 'changesetStatus' ).get() ) {
+					return false;
+				}
 				if ( '' === api.state( 'changesetStatus' ).get() && api.state( 'saved' ).get() ) {
 					return false;
 				}
@@ -6320,6 +6324,7 @@
 				section.active.set( isSectionActive() );
 			};
 			api.state( 'activated' ).bind( updateSectionActive );
+			api.state( 'trashing' ).bind( updateSectionActive );
 			api.state( 'saved' ).bind( updateSectionActive );
 			api.state( 'changesetStatus' ).bind( updateSectionActive );
 			updateSectionActive();
@@ -6846,6 +6851,7 @@
 		(function( state ) {
 			var saved = state.instance( 'saved' ),
 				saving = state.instance( 'saving' ),
+				trashing = state.instance( 'trashing' ),
 				activated = state.instance( 'activated' ),
 				processing = state.instance( 'processing' ),
 				paneVisible = state.instance( 'paneVisible' ),
@@ -6907,7 +6913,7 @@
 				 * Save (publish) button should be enabled if saving is not currently happening,
 				 * and if the theme is not active or the changeset exists but is not published.
 				 */
-				canSave = ! saving() && ( ! activated() || ! saved() || ( changesetStatus() !== selectedChangesetStatus() && '' !== changesetStatus() ) || ( 'future' === selectedChangesetStatus() && changesetDate.get() !== selectedChangesetDate.get() ) );
+				canSave = ! saving() && ! trashing() && ( ! activated() || ! saved() || ( changesetStatus() !== selectedChangesetStatus() && '' !== changesetStatus() ) || ( 'future' === selectedChangesetStatus() && changesetDate.get() !== selectedChangesetDate.get() ) );
 
 				saveBtn.prop( 'disabled', ! canSave );
 			});
@@ -6958,6 +6964,9 @@
 
 			saving.bind( function( isSaving ) {
 				body.toggleClass( 'saving', isSaving );
+			} );
+			trashing.bind( function( isTrashing ) {
+				body.toggleClass( 'trashing', isTrashing );
 			} );
 
 			api.bind( 'saved', function( response ) {

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -368,6 +368,12 @@
 		var deferred, request, submittedChanges = {}, data, submittedArgs;
 		deferred = new $.Deferred();
 
+		// Prevent attempting changeset update while request is being made.
+		if ( 0 !== api.state( 'processing' ).get() ) {
+			deferred.reject( 'already_processing' );
+			return deferred.promise();
+		}
+
 		submittedArgs = _.extend( {
 			title: null,
 			date: null,
@@ -6549,10 +6555,12 @@
 					 * due to dependencies on other settings.
 					 */
 					request = wp.ajax.post( 'customize_save', query );
+					api.state( 'processing' ).set( api.state( 'processing' ).get() + 1 );
 
 					api.trigger( 'save', request );
 
 					request.always( function () {
+						api.state( 'processing' ).set( api.state( 'processing' ).get() - 1 );
 						api.state( 'saving' ).set( false );
 						api.unbind( 'change', captureSettingModifiedDuringSave );
 					} );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -2909,7 +2909,7 @@
 
 				api.notifications.add( 'theme_installing', new api.OverlayNotification( 'theme_installing', {
 					message: api.l10n.themeDownloading,
-					type: 'notice',
+					type: 'info',
 					loading: true
 				} ) );
 			}
@@ -2946,7 +2946,7 @@
 			// Update loading message. Everything else is handled by reloading the page.
 			api.notifications.add( 'theme_previewing', new api.OverlayNotification( 'theme_previewing', {
 				message: api.l10n.themePreviewWait,
-				type: 'notice',
+				type: 'info',
 				loading: true
 			} ) );
 
@@ -6764,7 +6764,7 @@
 					nonce: api.settings.nonce.trash
 				} );
 				api.notifications.add( 'changeset_trashing', new api.OverlayNotification( 'changeset_trashing', {
-					type: 'notice',
+					type: 'info',
 					message: api.l10n.revertingChanges,
 					loading: true
 				} ) );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -7502,15 +7502,20 @@
 				isInsideIframe = true;
 			});
 
-			// Prompt user with AYS dialog if leaving the Customizer with unsaved changes
-			$( window ).on( 'beforeunload.customize-confirm', function() {
-				if ( ! isCleanState() ) {
-					setTimeout( function() {
-						overlay.removeClass( 'customize-loading' );
-					}, 1 );
-					return api.l10n.saveAlert;
-				}
-			});
+			function startPromptingBeforeUnload() {
+				api.unbind( 'change', startPromptingBeforeUnload );
+
+				// Prompt user with AYS dialog if leaving the Customizer with unsaved changes
+				$( window ).on( 'beforeunload.customize-confirm', function() {
+					if ( ! isCleanState() ) {
+						setTimeout( function() {
+							overlay.removeClass( 'customize-loading' );
+						}, 1 );
+						return api.l10n.saveAlert;
+					}
+				});
+			}
+			api.bind( 'change', startPromptingBeforeUnload );
 
 			closeBtn.on( 'click.customize-controls-close', function( event ) {
 				var clearedToClose = $.Deferred();
@@ -7957,8 +7962,10 @@
 		} );
 
 		// Autosave changeset.
-		( function() {
+		function startAutosaving() {
 			var timeoutId, updateChangesetWithReschedule, scheduleChangesetUpdate, updatePending = false;
+
+			api.unbind( 'change', startAutosaving ); // Ensure startAutosaving only fires once.
 
 			api.state( 'saved' ).bind( function( isSaved ) {
 				if ( ! isSaved && ! api.settings.changeset.autosaved ) {
@@ -8010,7 +8017,8 @@
 			$( window ).on( 'beforeunload.wp-customize-changeset-update', function() {
 				updateChangesetWithReschedule();
 			} );
-		} ());
+		}
+		api.bind( 'change', startAutosaving );
 
 		// Make sure TinyMCE dialogs appear above Customizer UI.
 		$( document ).one( 'wp-before-tinymce-init', function() {

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6303,7 +6303,35 @@
 			footerActions = $( '#customize-footer-actions' );
 
 		api.section( 'publish_settings', function( section ) {
-			var updateButtonsState, previewLinkControl, previewLinkControlId = 'changeset_preview_link', updateSectionActive, isSectionActive;
+			var updateButtonsState, previewLinkControl, TrashControl, trashControlInstance, trashControlId = 'trash_changeset', previewLinkControlId = 'changeset_preview_link', updateSectionActive, isSectionActive;
+
+			TrashControl = api.Control.extend( {
+
+				// This is a temporary hack while waiting for richer JS templating and dynamic instantiation.
+				embed: function() {
+					var control = this;
+					control.templateSelector = 'customize-trash-changeset-control';
+					return api.Control.prototype.embed.apply( control, arguments );
+				}
+			} );
+
+			trashControlInstance = new TrashControl( trashControlId, {
+				params: {
+					type: 'button',
+					section: section.id,
+					active: true,
+					priority: 30,
+					content: '<li id="customize-control-' + trashControlId + '" class="customize-control"></li>'
+				}
+			} );
+			api.control.add( trashControlId, trashControlInstance );
+			trashControlInstance.deferred.embedded.done( function() {
+				trashControlInstance.container.find( 'button' ).on( 'click', function() {
+					if ( confirm( api.l10n.trashConfirm ) ) {
+						wp.customize.previewer.trash();
+					}
+				} );
+			} );
 
 			previewLinkControl = new api.PreviewLinkControl( previewLinkControlId, {
 				params: {

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6279,8 +6279,6 @@
 			publishSettingsBtn = $( '#publish-settings' ),
 			footerActions = $( '#customize-footer-actions' );
 
-		saveBtn.show();
-
 		api.section( 'publish_settings', function( section ) {
 			var updateButtonsState, previewLinkControl, previewLinkControlId = 'changeset_preview_link', updateSectionActive, isSectionActive;
 
@@ -6301,7 +6299,7 @@
 			 * @return {boolean} Is section active.
 			 */
 			isSectionActive = function() {
-				if ( ! api.state( 'activated' ) ) {
+				if ( ! api.state( 'activated' ).get() ) {
 					return false;
 				}
 				if ( '' === api.state( 'changesetStatus' ).get() && api.state( 'saved' ).get() ) {
@@ -6552,14 +6550,10 @@
 					 */
 					request = wp.ajax.post( 'customize_save', query );
 
-					// Disable save button during the save request.
-					saveBtn.prop( 'disabled', true );
-
 					api.trigger( 'save', request );
 
 					request.always( function () {
 						api.state( 'saving' ).set( false );
-						saveBtn.prop( 'disabled', false );
 						api.unbind( 'change', captureSettingModifiedDuringSave );
 					} );
 
@@ -6863,7 +6857,6 @@
 				if ( ! activated() ) {
 					saveBtn.val( api.l10n.activate );
 					closeBtn.find( '.screen-reader-text' ).text( api.l10n.cancel );
-					publishSettingsBtn.prop( 'disabled', false );
 
 				} else if ( '' === changesetStatus.get() && saved() ) {
 					if ( api.settings.changeset.currentUserCanPublish ) {
@@ -6871,7 +6864,6 @@
 					} else {
 						saveBtn.val( api.l10n.saved );
 					}
-					publishSettingsBtn.prop( 'disabled', true );
 					closeBtn.find( '.screen-reader-text' ).text( api.l10n.close );
 
 				} else {
@@ -6899,7 +6891,6 @@
 						saveBtn.val( api.l10n.publish );
 					}
 					closeBtn.find( '.screen-reader-text' ).text( api.l10n.cancel );
-					publishSettingsBtn.prop( 'disabled', false );
 				}
 
 				/*
@@ -8049,6 +8040,7 @@
 			}
 		} );
 
+		body.addClass( 'ready' );
 		api.trigger( 'ready' );
 	});
 

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1817,7 +1817,7 @@
 			// Parameters for every API query. Additional params are set in PHP.
 			page = Math.ceil( section.loaded / 100 ) + 1;
 			params = {
-				'switch-themes-nonce': api.settings.nonce['switch-themes'],
+				'nonce': api.settings.nonce.switch_themes,
 				'wp_customize': 'on',
 				'theme_action': section.params.action,
 				'customized_theme': api.settings.theme.stylesheet,
@@ -1834,7 +1834,7 @@
 			section.headContainer.closest( '.wp-full-overlay' ).addClass( 'loading' );
 			section.loading = true;
 			section.container.find( '.no-themes' ).hide();
-			request = wp.ajax.post( 'customize-load-themes', params );
+			request = wp.ajax.post( 'customize_load_themes', params );
 			request.done(function( data ) {
 				var themes = data.themes, themeControl, newThemeControls;
 
@@ -7225,7 +7225,7 @@
 
 						// Handle dismissal of notice.
 						li.find( '.notice-dismiss' ).on( 'click', function() {
-							wp.ajax.post( 'dismiss_customize_changeset_autosave', {
+							wp.ajax.post( 'customize_dismiss_autosave', {
 								wp_customize: 'on',
 								customize_theme: api.settings.theme.stylesheet,
 								customize_changeset_uuid: api.settings.changeset.uuid,
@@ -7691,7 +7691,7 @@
 					if ( '' === api.state( 'changesetStatus' ).get() ) {
 						clearedToClose.resolve();
 					} else {
-						wp.ajax.send( 'dismiss_customize_changeset_autosave', {
+						wp.ajax.send( 'customize_dismiss_autosave', {
 							timeout: 500, // Don't wait too long.
 							data: {
 								wp_customize: 'on',

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6197,7 +6197,6 @@
 	api.state = new api.Values();
 	_.each( [
 		'saved',
-		'autosaved',
 		'saving',
 		'trashing',
 		'activated',

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6638,7 +6638,9 @@
 						previewer.send( 'saved', response );
 
 						api.state( 'changesetStatus' ).set( response.changeset_status );
-						api.state( 'changesetDate' ).set( response.changeset_date );
+						if ( response.changeset_date ) {
+							api.state( 'changesetDate' ).set( response.changeset_date );
+						}
 
 						if ( 'publish' === response.changeset_status ) {
 

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -2909,7 +2909,6 @@
 
 				api.notifications.add( 'theme_installing', new api.OverlayNotification( 'theme_installing', {
 					message: api.l10n.themeDownloading,
-					dismissible: true,
 					type: 'notice',
 					loading: true
 				} ) );
@@ -2947,7 +2946,6 @@
 			// Update loading message. Everything else is handled by reloading the page.
 			api.notifications.add( 'theme_previewing', new api.OverlayNotification( 'theme_previewing', {
 				message: api.l10n.themePreviewWait,
-				dismissible: false,
 				type: 'notice',
 				loading: true
 			} ) );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6301,35 +6301,7 @@
 			footerActions = $( '#customize-footer-actions' );
 
 		api.section( 'publish_settings', function( section ) {
-			var updateButtonsState, previewLinkControl, TrashControl, trashControlInstance, trashControlId = 'trash_changeset', previewLinkControlId = 'changeset_preview_link', updateSectionActive, isSectionActive;
-
-			TrashControl = api.Control.extend( {
-
-				// This is a temporary hack while waiting for richer JS templating and dynamic instantiation.
-				embed: function() {
-					var control = this;
-					control.templateSelector = 'customize-trash-changeset-control';
-					return api.Control.prototype.embed.apply( control, arguments );
-				}
-			} );
-
-			trashControlInstance = new TrashControl( trashControlId, {
-				params: {
-					type: 'button',
-					section: section.id,
-					active: true,
-					priority: 30,
-					content: '<li id="customize-control-' + trashControlId + '" class="customize-control"></li>'
-				}
-			} );
-			api.control.add( trashControlId, trashControlInstance );
-			trashControlInstance.deferred.embedded.done( function() {
-				trashControlInstance.container.find( 'button' ).on( 'click', function() {
-					if ( confirm( api.l10n.trashConfirm ) ) {
-						wp.customize.previewer.trash();
-					}
-				} );
-			} );
+			var updateButtonsState, previewLinkControl, previewLinkControlId = 'changeset_preview_link', updateSectionActive, isSectionActive;
 
 			previewLinkControl = new api.PreviewLinkControl( previewLinkControlId, {
 				params: {

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3636,6 +3636,9 @@ final class WP_Customize_Manager {
 				</label>
 			</div>
 		</script>
+		<script type="text/html" id="tmpl-customize-trash-changeset-control">
+			<button type="button" class="button-link button-link-delete"><?php _e( 'Trash unpublished changes' ); ?></button>
+		</script>
 		<?php
 	}
 
@@ -4220,6 +4223,7 @@ final class WP_Customize_Manager {
 
 		$this->add_control( 'changeset_status', array(
 			'section' => 'publish_settings',
+			'priority' => 10,
 			'settings' => array(),
 			'type' => 'radio',
 			'label' => __( 'Action' ),
@@ -4234,6 +4238,7 @@ final class WP_Customize_Manager {
 		}
 		$this->add_control( new WP_Customize_Date_Time_Control( $this, 'changeset_scheduled_date', array(
 			'section' => 'publish_settings',
+			'priority' => 20,
 			'settings' => array(),
 			'type' => 'date_time',
 			'min_year' => date( 'Y' ),

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -374,11 +374,11 @@ final class WP_Customize_Manager {
 		remove_action( 'admin_init', '_maybe_update_plugins' );
 		remove_action( 'admin_init', '_maybe_update_themes' );
 
-		add_action( 'wp_ajax_customize_save',           array( $this, 'save' ) );
-		add_action( 'wp_ajax_customize_trash',          array( $this, 'handle_changeset_trash_request' ) );
-		add_action( 'wp_ajax_customize_refresh_nonces', array( $this, 'refresh_nonces' ) );
-		add_action( 'wp_ajax_customize-load-themes',    array( $this, 'load_themes_ajax' ) );
-		add_action( 'wp_ajax_dismiss_customize_changeset_autosave', array( $this, 'handle_dismiss_changeset_autosave_request' ) );
+		add_action( 'wp_ajax_customize_save',             array( $this, 'save' ) );
+		add_action( 'wp_ajax_customize_trash',            array( $this, 'handle_changeset_trash_request' ) );
+		add_action( 'wp_ajax_customize_refresh_nonces',   array( $this, 'refresh_nonces' ) );
+		add_action( 'wp_ajax_customize_load_themes',      array( $this, 'handle_load_themes_request' ) );
+		add_action( 'wp_ajax_customize_dismiss_autosave', array( $this, 'handle_dismiss_autosave_request' ) );
 
 		add_action( 'customize_register',                 array( $this, 'register_controls' ) );
 		add_action( 'customize_register',                 array( $this, 'register_dynamic_settings' ), 11 ); // allow code to create settings first
@@ -3162,12 +3162,12 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 4.9.0
 	 */
-	public function handle_dismiss_changeset_autosave_request() {
+	public function handle_dismiss_autosave_request() {
 		if ( ! $this->is_preview() ) {
 			wp_send_json_error( 'not_preview', 400 );
 		}
 
-		if ( ! check_ajax_referer( 'dismiss_customize_changeset_autosave', 'nonce', false ) ) {
+		if ( ! check_ajax_referer( 'customize_dismiss_autosave', 'nonce', false ) ) {
 			wp_send_json_error( 'invalid_nonce', 403 );
 		}
 
@@ -3964,8 +3964,8 @@ final class WP_Customize_Manager {
 		$nonces = array(
 			'save' => wp_create_nonce( 'save-customize_' . $this->get_stylesheet() ),
 			'preview' => wp_create_nonce( 'preview-customize_' . $this->get_stylesheet() ),
-			'switch-themes' => wp_create_nonce( 'switch-themes' ),
-			'dismiss_autosave' => wp_create_nonce( 'dismiss_customize_changeset_autosave' ),
+			'switch_themes' => wp_create_nonce( 'switch_themes' ),
+			'dismiss_autosave' => wp_create_nonce( 'customize_dismiss_autosave' ),
 			'trash' => wp_create_nonce( 'trash_customize_changeset' ),
 		);
 
@@ -4789,8 +4789,8 @@ final class WP_Customize_Manager {
 	 *
 	 * @since 4.9.0
 	 */
-	public function load_themes_ajax() {
-		check_ajax_referer( 'switch-themes', 'switch-themes-nonce' );
+	public function handle_load_themes_request() {
+		check_ajax_referer( 'switch_themes', 'nonce' );
 
 		if ( ! current_user_can( 'switch_themes' ) ) {
 			wp_die( -1 );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3543,8 +3543,8 @@ final class WP_Customize_Manager {
 
 		?>
 		<script type="text/html" id="tmpl-customize-notification">
-			<li class="notice notice-{{ data.type || 'info' }} {{ data.alt ? 'notice-alt' : '' }} {{ data.dismissible ? 'is-dismissible' : '' }}" data-code="{{ data.code }}" data-type="{{ data.type }}">
-				{{{ data.message || data.code }}}
+			<li class="notice notice-{{ data.type || 'info' }} {{ data.alt ? 'notice-alt' : '' }} {{ data.dismissible ? 'is-dismissible' : '' }} {{ data.classes || '' }}" data-code="{{ data.code }}" data-type="{{ data.type }}">
+				<div class="notification-message">{{{ data.message || data.code }}}</div>
 				<# if ( data.dismissible ) { #>
 					<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php _e( 'Dismiss' ); ?></span></button>
 				<# } #>

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2853,19 +2853,19 @@ final class WP_Customize_Manager {
 
 		$changeset_post_id = $this->changeset_post_id();
 
-		if ( $changeset_post_id && ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->delete_post, $changeset_post_id ) ) {
-			wp_send_json_error( array(
-				'code' => 'changeset_trash_unauthorized',
-				'message' => __( 'Unable to trash changes.' ),
-			) );
-		}
-
 		if ( ! $changeset_post_id ) {
 			wp_send_json_error( array(
 				'message' => __( 'No changes saved yet, so there is nothing to trash.' ),
 				'code' => 'non_existent_changeset',
 			) );
 			return;
+		}
+
+		if ( $changeset_post_id && ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->delete_post, $changeset_post_id ) ) {
+			wp_send_json_error( array(
+				'code' => 'changeset_trash_unauthorized',
+				'message' => __( 'Unable to trash changes.' ),
+			) );
 		}
 
 		if ( 'trash' === get_post_status( $changeset_post_id ) ) {

--- a/src/wp-includes/customize/class-wp-customize-themes-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-themes-panel.php
@@ -89,10 +89,6 @@ class WP_Customize_Themes_Panel extends WP_Customize_Panel {
 				<# } #>
 			<?php endif; ?>
 		</li>
-		<li id="customize-themes-loading-container">
-			<span class="customize-loading-text-installing-theme"><?php _e( 'Downloading your new theme&hellip;' ); ?></span>
-			<span class="customize-loading-text"><?php _e( 'Setting up your live preview. This may take a bit.' ); ?></span>
-		</li><?php // Used as a full-screen overlay transition after clicking to preview a theme. ?>
 		<li class="customize-themes-full-container-container">
 			<ul class="customize-themes-full-container">
 				<li class="customize-themes-notifications"></li>

--- a/src/wp-includes/js/customize-base.js
+++ b/src/wp-includes/js/customize-base.js
@@ -810,6 +810,14 @@ window.wp = window.wp || {};
 		templateId: 'customize-notification',
 
 		/**
+		 * Additional class names to add to the notification container.
+		 *
+		 * @since 4.9.0
+		 * @var {string}
+		 */
+		classes: '',
+
+		/**
 		 * Initialize notification.
 		 *
 		 * @since 4.9.0
@@ -821,6 +829,7 @@ window.wp = window.wp || {};
 		 * @param {string}   [params.setting] - Related setting ID.
 		 * @param {Function} [params.template] - Function for rendering template. If not provided, this will come from templateId.
 		 * @param {string}   [params.templateId] - ID for template to render the notification.
+		 * @param {string}   [params.classes] - Additional class names to add to the notification container.
 		 * @param {boolean}  [params.dismissible] - Whether the notification can be dismissed.
 		 */
 		initialize: function( code, params ) {
@@ -834,7 +843,8 @@ window.wp = window.wp || {};
 					data: null,
 					setting: null,
 					template: null,
-					dismissible: false
+					dismissible: false,
+					classes: ''
 				},
 				params
 			);

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -571,6 +571,8 @@ function wp_default_scripts( &$scripts ) {
 		'expandSidebar'      => _x( 'Show Controls', 'label for hide controls button without length constraints' ),
 		'untitledBlogName'   => __( '(Untitled)' ),
 		'serverSaveError'    => __( 'Failed connecting to the server. Please try saving again.' ),
+		'themeDownloading'   => __( 'Downloading your new theme&hellip;' ),
+		'themePreviewWait'   => __( 'Setting up your live preview. This may take a bit.' ),
 		/* translators: %s: URL to the Customizer to load the autosaved version */
 		'autosaveNotice'     => __( 'There is a more recent autosave of your changes than the one you are previewing. <a href="%s">Restore the autosave</a>' ),
 		'videoHeaderNotice'  => __( 'This theme doesn\'t support video headers on this page. Navigate to the front page or another page that supports video headers.' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -574,6 +574,7 @@ function wp_default_scripts( &$scripts ) {
 		'themeDownloading'   => __( 'Downloading your new theme&hellip;' ),
 		'themePreviewWait'   => __( 'Setting up your live preview. This may take a bit.' ),
 		'revertingChanges'   => __( 'Reverting unpublished changes&hellip;' ),
+		'trashConfirm'       => __( 'Are you sure you would like to discard your unpublished changes?' ),
 		/* translators: %s: URL to the Customizer to load the autosaved version */
 		'autosaveNotice'     => __( 'There is a more recent autosave of your changes than the one you are previewing. <a href="%s">Restore the autosave</a>' ),
 		'videoHeaderNotice'  => __( 'This theme doesn\'t support video headers on this page. Navigate to the front page or another page that supports video headers.' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -573,6 +573,7 @@ function wp_default_scripts( &$scripts ) {
 		'serverSaveError'    => __( 'Failed connecting to the server. Please try saving again.' ),
 		'themeDownloading'   => __( 'Downloading your new theme&hellip;' ),
 		'themePreviewWait'   => __( 'Setting up your live preview. This may take a bit.' ),
+		'revertingChanges'   => __( 'Reverting unpublished changes&hellip;' ),
 		/* translators: %s: URL to the Customizer to load the autosaved version */
 		'autosaveNotice'     => __( 'There is a more recent autosave of your changes than the one you are previewing. <a href="%s">Restore the autosave</a>' ),
 		'videoHeaderNotice'  => __( 'This theme doesn\'t support video headers on this page. Navigate to the front page or another page that supports video headers.' ),

--- a/tests/phpunit/tests/ajax/CustomizeManager.php
+++ b/tests/phpunit/tests/ajax/CustomizeManager.php
@@ -516,20 +516,20 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 	 * Test request for dismissing autosave changesets.
 	 *
 	 * @ticket 39896
-	 * @covers WP_Customize_Manager::handle_dismiss_changeset_autosave_request()
+	 * @covers WP_Customize_Manager::handle_dismiss_autosave_request()
 	 * @covers WP_Customize_Manager::dismiss_user_auto_draft_changesets()
 	 */
-	public function test_handle_dismiss_changeset_autosave_request() {
+	public function test_handle_dismiss_autosave_request() {
 		$uuid = wp_generate_uuid4();
 		$wp_customize = $this->set_up_valid_state( $uuid );
 
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'invalid_nonce', $this->_last_response_parsed['data'] );
 
-		$nonce = wp_create_nonce( 'dismiss_customize_changeset_autosave' );
+		$nonce = wp_create_nonce( 'customize_dismiss_autosave' );
 		$_POST['nonce'] = $_GET['nonce'] = $_REQUEST['nonce'] = $nonce;
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'no_auto_draft_to_delete', $this->_last_response_parsed['data'] );
 
@@ -559,7 +559,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		foreach ( array_merge( $user_auto_draft_ids, $other_user_auto_draft_ids ) as $post_id ) {
 			$this->assertFalse( (bool) get_post_meta( $post_id, '_customize_restore_dismissed', true ) );
 		}
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertTrue( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'auto_draft_dismissed', $this->_last_response_parsed['data'] );
 		foreach ( $user_auto_draft_ids as $post_id ) {
@@ -572,7 +572,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		}
 
 		// Subsequent test results in none dismissed.
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'no_auto_draft_to_delete', $this->_last_response_parsed['data'] );
 
@@ -590,7 +590,7 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		$this->assertContains( 'Foo', get_post( $wp_customize->changeset_post_id() )->post_content );
 
 		// Since no autosave yet, confirm no action.
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'no_autosave_revision_to_delete', $this->_last_response_parsed['data'] );
 
@@ -610,13 +610,13 @@ class Tests_Ajax_CustomizeManager extends WP_Ajax_UnitTestCase {
 		$this->assertContains( 'Bar', $autosave_revision->post_content );
 
 		// Confirm autosave gets deleted.
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertTrue( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'autosave_revision_deleted', $this->_last_response_parsed['data'] );
 		$this->assertFalse( wp_get_post_autosave( $wp_customize->changeset_post_id() ) );
 
 		// Since no autosave yet, confirm no action.
-		$this->make_ajax_call( 'dismiss_customize_changeset_autosave' );
+		$this->make_ajax_call( 'customize_dismiss_autosave' );
 		$this->assertFalse( $this->_last_response_parsed['success'] );
 		$this->assertEquals( 'no_autosave_revision_to_delete', $this->_last_response_parsed['data'] );
 	}


### PR DESCRIPTION
Changes have been deployed to http://trac-39896-xwp-testbed.pantheonsite.io/wp-admin/customize.php

This PR does various cleanup of code related to drafting/scheduling and the new experience for themes.

* Add a new trash button to Publish Settings section that invokes a new `wp.customize.previewer.trash()` to trash the current changeset. Add logic to `WP_Customize_Manager` to handle deleting changeset drafts. Add `trashing` to `wp.customize.state` which is then used to update the UI.
* Improve logic for managing the visibility and disabled states for publish buttons.
* Prevent attempting `requestChangesetUpdate` while processing and bump processing while doing `save`.
* Only update `changeset_date` state if sent in save response.
* Merge `ThemesSection#loadThemePreview()` into `ThemesPanel#loadThemePreview()`.
* Remove unused `autosaved` state.
* Start autosaving and prompting at beforeunload after a change first happens. This is key for theme previews since even if a user did not make any changes, there were still dirty settings which would get stored in an auto-draft unexpectedly.
* Allow `Notification` to accept additional `classes` to be added to `container`.
* Introduce `OverlayNotification` and use for theme installing, previewing, and trashing. Such overlay notifications take over the entire window.

- [x] Add unit tests for trashing.
- [ ] Add keyboard-accessibility to publish settings (needs tabindex work).

See:

* https://core.trac.wordpress.org/ticket/39896
* https://core.trac.wordpress.org/ticket/37661
* https://core.trac.wordpress.org/ticket/21666

