### PR TITLE
#40254: Eliminate use of customize-loader

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -7,6 +7,10 @@
   16.1 - Manage Themes
 ------------------------------------------------------------------------------*/
 
+body.js .theme-browser.search-loading {
+	display: none;
+}
+
 .theme-browser .themes {
 	clear: both;
 }

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -64,7 +64,14 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 		$install_actions = array();
 
 		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
-			$install_actions['preview'] = '<a href="' . wp_customize_url( $stylesheet ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Live Preview' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Live Preview &#8220;%s&#8221;' ), $name ) . '</span></a>';
+			$customize_url = add_query_arg(
+				array(
+					'theme' => urlencode( $stylesheet ),
+					'return' => urlencode( admin_url( 'web' === $this->type ? 'theme-install.php' : 'themes.php' ) ),
+				),
+				admin_url( 'customize.php' )
+			);
+			$install_actions['preview'] = '<a href="' . esc_url( $customize_url ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Live Preview' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Live Preview &#8220;%s&#8221;' ), $name ) . '</span></a>';
 		}
 		$install_actions['activate'] = '<a href="' . esc_url( $activate_link ) . '" class="activatelink"><span aria-hidden="true">' . __( 'Activate' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Activate &#8220;%s&#8221;' ), $name ) . '</span></a>';
 

--- a/src/wp-admin/includes/class-theme-upgrader-skin.php
+++ b/src/wp-admin/includes/class-theme-upgrader-skin.php
@@ -49,13 +49,20 @@ class Theme_Upgrader_Skin extends WP_Upgrader_Skin {
 			), admin_url('themes.php') );
 			$activate_link = wp_nonce_url( $activate_link, 'switch-theme_' . $stylesheet );
 
+			$customize_url = add_query_arg(
+				array(
+					'theme' => urlencode( $stylesheet ),
+					'return' => urlencode( admin_url( 'themes.php' ) ),
+				),
+				admin_url( 'customize.php' )
+			);
 			if ( get_stylesheet() == $stylesheet ) {
 				if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
-					$update_actions['preview']  = '<a href="' . wp_customize_url( $stylesheet ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Customize' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Customize &#8220;%s&#8221;' ), $name ) . '</span></a>';
+					$update_actions['preview']  = '<a href="' . esc_url( $customize_url ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Customize' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Customize &#8220;%s&#8221;' ), $name ) . '</span></a>';
 				}
 			} elseif ( current_user_can( 'switch_themes' ) ) {
 				if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
-					$update_actions['preview'] = '<a href="' . wp_customize_url( $stylesheet ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Live Preview' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Live Preview &#8220;%s&#8221;' ), $name ) . '</span></a>';
+					$update_actions['preview'] = '<a href="' . esc_url( $customize_url ) . '" class="hide-if-no-customize load-customize"><span aria-hidden="true">' . __( 'Live Preview' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Live Preview &#8220;%s&#8221;' ), $name ) . '</span></a>';
 				}
 				$update_actions['activate'] = '<a href="' . esc_url( $activate_link ) . '" class="activatelink"><span aria-hidden="true">' . __( 'Activate' ) . '</span><span class="screen-reader-text">' . sprintf( __( 'Activate &#8220;%s&#8221;' ), $name ) . '</span></a>';
 			}

--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -16,8 +16,6 @@ wp_dashboard_setup();
 
 wp_enqueue_script( 'dashboard' );
 
-if ( current_user_can( 'edit_theme_options' ) )
-	wp_enqueue_script( 'customize-loader' );
 if ( current_user_can( 'install_plugins' ) ) {
 	wp_enqueue_script( 'plugin-install' );
 	wp_enqueue_script( 'updates' );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -3045,7 +3045,7 @@
 				request.done( function() {
 					deferred.resolve();
 					$( window ).off( 'beforeunload.customize-confirm' );
-					window.location.href = urlParser.href; // @todo Use location.replace()?
+					location.replace( urlParser.href );
 				} );
 				request.fail( function() {
 

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -7986,7 +7986,9 @@
 			parent.send( 'title', newTitle );
 		});
 
-		parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+		if ( api.settings.changeset.branching ) {
+			parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+		}
 
 		// Initialize the connection with the parent frame.
 		parent.send( 'ready' );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -6959,7 +6959,9 @@
 						if ( 'changeset_already_published' === response.code && response.next_changeset_uuid ) {
 							api.settings.changeset.uuid = response.next_changeset_uuid;
 							api.state( 'changesetStatus' ).set( '' );
-							parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+							if ( api.settings.changeset.branching ) {
+								parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+							}
 							api.previewer.send( 'changeset-uuid', api.settings.changeset.uuid );
 						}
 					} );
@@ -6990,7 +6992,9 @@
 
 							api.state( 'changesetStatus' ).set( '' );
 							api.settings.changeset.uuid = response.next_changeset_uuid;
-							parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+							if ( api.settings.changeset.branching ) {
+								parent.send( 'changeset-uuid', api.settings.changeset.uuid );
+							}
 						}
 
 						// Prevent subsequent requestChangesetUpdate() calls from including the settings that have been saved.

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -3014,7 +3014,8 @@
 				api.utils.parseQueryString( urlParser.search.substr( 1 ) ),
 				{
 					theme: themeId,
-					changeset_uuid: api.settings.changeset.uuid
+					changeset_uuid: api.settings.changeset.uuid,
+					'return': api.settings.url['return']
 				}
 			);
 
@@ -7065,6 +7066,7 @@
 					urlParser.href = location.href;
 					queryParams = api.utils.parseQueryString( urlParser.search.substr( 1 ) );
 					delete queryParams.changeset_uuid;
+					queryParams['return'] = api.settings.url['return'];
 					urlParser.search = $.param( queryParams );
 					location.replace( urlParser.href );
 				};
@@ -7418,6 +7420,7 @@
 				} else {
 					queryParams.customize_autosaved = 'on';
 				}
+				queryParams['return'] = api.settings.url['return'];
 				urlParser.search = $.param( queryParams );
 				return urlParser.href;
 			}

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -1345,14 +1345,12 @@ themes.view.Search = wp.Backbone.View.extend({
 			event.target.value = '';
 		}
 
-		/**
-		 * Since doSearch is debounced, it will only run when user input comes to a rest
-		 */
+		// Note that doSearch is throttled.
 		this.doSearch( event );
 	},
 
 	// Runs a search on the theme collection.
-	doSearch: _.debounce( function( event ) {
+	doSearch: _.throttle( function( event ) {
 		var options = {};
 
 		this.collection.doSearch( event.target.value );
@@ -1561,7 +1559,7 @@ themes.view.InstallerSearch =  themes.view.Search.extend({
 		this.doSearch( event.target.value );
 	},
 
-	doSearch: _.debounce( function( value ) {
+	doSearch: _.throttle( function( value ) {
 		var request = {};
 
 		// Don't do anything if the search terms haven't changed.

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -1386,44 +1386,7 @@ themes.view.Search = wp.Backbone.View.extend({
 });
 
 /**
- * Add a return param the supplied URL.
- *
- * @since 4.9.0
- *
- * @param {string} url - Original URL.
- * @param {string} returnUrl - Value for the return param.
- * @returns {string} URL with return param appended to it.
- */
-function addReturnUrlParam( url, returnUrl ) {
-	var urlParser = document.createElement( 'a' );
-	urlParser.href = url;
-	urlParser.search = $.param( _.extend(
-		wp.customize.utils.parseQueryString( urlParser.search.substr( 1 ) ),
-		{
-			'return': returnUrl
-		}
-	) );
-	return urlParser.href;
-}
-
-/**
- * Update the return param in any links to the Customizer to reflect the current location.
- *
- * @since 4.9.0
- *
- * @returns {void}
- */
-function updateCustomizeLoadLinks() {
-	$( '.load-customize' ).each( function() {
-		var link = $( this );
-		link.prop( 'href', addReturnUrlParam( link.prop( 'href' ), window.location.href ) );
-	} );
-}
-
-/**
  * Navigate router.
- *
- * Update links to Customizer whenever history.pushState() will be called.
  *
  * @since 4.9.0
  *
@@ -1435,12 +1398,8 @@ function navigateRouter( url, state ) {
 	var router = this;
 	if ( Backbone.history._hasPushState ) {
 		Backbone.Router.prototype.navigate.call( router, url, state );
-		updateCustomizeLoadLinks();
 	}
 }
-
-// Update links to Customizer whenever popstate happens.
-$( window ).on( 'popstate', updateCustomizeLoadLinks );
 
 // Sets up the routes events for relevant url queries
 // Listens to [theme] and [search] params
@@ -2051,6 +2010,19 @@ $( document ).ready(function() {
 	} else {
 		themes.Run.init();
 	}
+
+	// Update the return param just in time.
+	$( document.body ).on( 'click', '.load-customize', function() {
+		var link = $( this ), urlParser = document.createElement( 'a' );
+		urlParser.href = link.prop( 'href' );
+		urlParser.search = $.param( _.extend(
+			wp.customize.utils.parseQueryString( urlParser.search.substr( 1 ) ),
+			{
+				'return': window.location.href
+			}
+		) );
+		link.prop( 'href', urlParser.href );
+	});
 
 	$( '.broken-themes .delete-theme' ).on( 'click', function() {
 		return confirm( _wpThemeSettings.settings.confirmDelete );

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -1355,7 +1355,7 @@ themes.view.Search = wp.Backbone.View.extend({
 	doSearch: _.throttle( function( event ) {
 		var options = {};
 
-		this.collection.doSearch( event.target.value );
+		this.collection.doSearch( event.target.value.replace( /\+/g, ' ' ) );
 
 		// if search is initiated and key is not return
 		if ( this.searching && event.which !== 13 ) {
@@ -1376,7 +1376,7 @@ themes.view.Search = wp.Backbone.View.extend({
 		var url = themes.router.baseUrl( '' );
 
 		if ( event.target.value ) {
-			url = themes.router.baseUrl( themes.router.searchPath + event.target.value );
+			url = themes.router.baseUrl( themes.router.searchPath + encodeURIComponent( event.target.value ) );
 		}
 
 		this.searching = false;
@@ -1421,7 +1421,7 @@ themes.Router = Backbone.Router.extend({
 	searchPath: '?search=',
 
 	search: function( query ) {
-		$( '.wp-filter-search' ).val( query );
+		$( '.wp-filter-search' ).val( query.replace( /\+/g, ' ' ) );
 	},
 
 	themes: function() {
@@ -1563,7 +1563,7 @@ themes.view.InstallerSearch =  themes.view.Search.extend({
 		this.collection.query( request );
 
 		// Set route
-		themes.router.navigate( themes.router.baseUrl( themes.router.searchPath + value ), { replace: true } );
+		themes.router.navigate( themes.router.baseUrl( themes.router.searchPath + encodeURIComponent( value ) ), { replace: true } );
 	}, 500 )
 });
 
@@ -1899,7 +1899,7 @@ themes.InstallerRouter = Backbone.Router.extend({
 	searchPath: '?search=',
 
 	search: function( query ) {
-		$( '.wp-filter-search' ).val( query );
+		$( '.wp-filter-search' ).val( query.replace( /\+/g, ' ' ) );
 	},
 
 	navigate: navigateRouter

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -77,6 +77,8 @@ themes.view.Appearance = wp.Backbone.View.extend({
 		// Render search form.
 		this.search();
 
+		this.$el.removeClass( 'search-loading' );
+
 		// Render and append
 		this.view.render();
 		this.$el.empty().append( this.view.el ).addClass( 'rendered' );

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -146,7 +146,6 @@ wp_localize_script( 'theme', '_wpThemeSettings', array(
 add_thickbox();
 wp_enqueue_script( 'theme' );
 wp_enqueue_script( 'updates' );
-wp_enqueue_script( 'customize-loader' );
 
 require_once( ABSPATH . 'wp-admin/admin-header.php' );
 ?>

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -152,7 +152,7 @@ require_once( ABSPATH . 'wp-admin/admin-header.php' );
 
 <div class="wrap">
 	<h1 class="wp-heading-inline"><?php esc_html_e( 'Themes' ); ?>
-		<span class="title-count theme-count"><?php echo count( $themes ); ?></span>
+		<span class="title-count theme-count"><?php echo ! empty( $_GET['search'] ) ? __( '&hellip;' ) : count( $themes ); ?></span>
 	</h1>
 
 	<?php if ( ! is_multisite() && current_user_can( 'install_themes' ) ) : ?>
@@ -233,7 +233,13 @@ if ( ! $ct->errors() || ( 1 == count( $ct->errors()->get_error_codes() )
 
 ?>
 
-<div class="theme-browser">
+<?php
+$class_name = 'theme-browser';
+if ( ! empty( $_GET['search'] ) ) {
+	$class_name .= ' search-loading';
+}
+?>
+<div class="<?php echo esc_attr( $class_name ); ?>">
 	<div class="themes wp-clearfix">
 
 <?php

--- a/src/wp-admin/update.php
+++ b/src/wp-admin/update.php
@@ -173,7 +173,6 @@ if ( isset($_GET['action']) ) {
 
 		check_admin_referer('upgrade-theme_' . $theme);
 
-		wp_enqueue_script( 'customize-loader' );
 		wp_enqueue_script( 'updates' );
 
 		$title = __('Update Theme');
@@ -223,10 +222,9 @@ if ( isset($_GET['action']) ) {
 		check_admin_referer( 'install-theme_' . $theme );
 		$api = themes_api('theme_information', array('slug' => $theme, 'fields' => array('sections' => false, 'tags' => false) ) ); //Save on a bit of bandwidth.
 
-		if ( is_wp_error($api) )
-	 		wp_die($api);
-
-		wp_enqueue_script( 'customize-loader' );
+		if ( is_wp_error( $api ) ) {
+			wp_die( $api );
+		}
 
 		$title = __('Install Themes');
 		$parent_file = 'themes.php';
@@ -252,8 +250,6 @@ if ( isset($_GET['action']) ) {
 		check_admin_referer('theme-upload');
 
 		$file_upload = new File_Upload_Upgrader('themezip', 'package');
-
-		wp_enqueue_script( 'customize-loader' );
 
 		$title = __('Upload Theme');
 		$parent_file = 'themes.php';

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -4236,6 +4236,7 @@ final class WP_Customize_Manager {
 			),
 			'url'      => array(
 				'preview'       => esc_url_raw( $this->get_preview_url() ),
+				'return'        => esc_url_raw( $this->get_return_url() ),
 				'parent'        => esc_url_raw( admin_url() ),
 				'activated'     => esc_url_raw( home_url( '/' ) ),
 				'ajax'          => esc_url_raw( admin_url( 'admin-ajax.php', 'relative' ) ),

--- a/src/wp-includes/js/customize-loader.js
+++ b/src/wp-includes/js/customize-loader.js
@@ -208,25 +208,30 @@ window.wp = window.wp || {};
 		 * Close the Customizer overlay.
 		 */
 		close: function() {
-			if ( ! this.active ) {
+			var self = this, onConfirmClose;
+			if ( ! self.active ) {
 				return;
 			}
 
-			// Display AYS dialog if Customizer is dirty
-			if ( ! this.saved() && ! confirm( Loader.settings.l10n.saveAlert ) ) {
-				// Go forward since Customizer is exited by history.back()
-				history.forward();
-				return;
-			}
+			onConfirmClose = function( confirmed ) {
+				if ( confirmed ) {
+					self.active = false;
+					self.trigger( 'close' );
 
-			this.active = false;
+					// Restore document title prior to opening the Live Preview
+					if ( self.originalDocumentTitle ) {
+						document.title = self.originalDocumentTitle;
+					}
+				} else {
 
-			this.trigger( 'close' );
+					// Go forward since Customizer is exited by history.back()
+					history.forward();
+				}
+				self.messenger.unbind( 'confirmed-close', onConfirmClose );
+			};
+			self.messenger.bind( 'confirmed-close', onConfirmClose );
 
-			// Restore document title prior to opening the Live Preview
-			if ( this.originalDocumentTitle ) {
-				document.title = this.originalDocumentTitle;
-			}
+			Loader.messenger.send( 'confirm-close' );
 		},
 
 		/**

--- a/src/wp-includes/js/customize-loader.js
+++ b/src/wp-includes/js/customize-loader.js
@@ -1,4 +1,4 @@
-/* global _wpCustomizeLoaderSettings, confirm */
+/* global _wpCustomizeLoaderSettings */
 /**
  * Expose a public API that allows the customizer to be
  * loaded on any page.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -725,7 +725,7 @@ function wp_default_scripts( &$scripts ) {
 		$scripts->add( 'text-widgets', "/wp-admin/js/widgets/text-widgets$suffix.js", array( 'jquery', 'backbone', 'editor', 'wp-util', 'wp-a11y' ) );
 		$scripts->add( 'custom-html-widgets', "/wp-admin/js/widgets/custom-html-widgets$suffix.js", array( 'code-editor', 'jquery', 'backbone', 'wp-util', 'jquery-ui-core', 'wp-a11y' ) );
 
-		$scripts->add( 'theme', "/wp-admin/js/theme$suffix.js", array( 'wp-backbone', 'wp-a11y' ), false, 1 );
+		$scripts->add( 'theme', "/wp-admin/js/theme$suffix.js", array( 'wp-backbone', 'wp-a11y', 'customize-base' ), false, 1 );
 
 		$scripts->add( 'inline-edit-post', "/wp-admin/js/inline-edit-post$suffix.js", array( 'jquery', 'tags-suggest', 'wp-a11y' ), false, 1 );
 		did_action( 'init' ) && $scripts->localize( 'inline-edit-post', 'inlineEditL10n', array(


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/40254

- [x] When the Customizer reloads due to theme switches or trashing of changesets, make sure the original `return` param gets inserted into the URL that is replaced as otherwise the referer is lost.
- [x] Update `themes.php` to hide initial list of themes until JS initializes to prevent momentary flash of non-filtered themes. This is only necessary when the `search` param is present.
- [x] Add back-compat for customize-loader with the AYS dialog and dismissing autosaves.