### PR TITLE
Customizer: Add New Menu button to All Locations view

### DIFF
--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -32,8 +32,9 @@
 	color: #555;
 }
 
-/* The `edit-menu` button uses also the `button-link` class. */
-.customize-control-nav_menu_location .edit-menu {
+/* The `edit-menu` and `create-menu` buttons also use the `button-link` class. */
+.customize-control-nav_menu_location .edit-menu,
+.customize-control-nav_menu_location .create-menu {
 	margin-left: 6px;
 	vertical-align: middle;
 	line-height: 28px;

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1383,6 +1383,26 @@
 
 			// Focus on the new menu section.
 			api.section( customizeId ).focus(); // @todo should we focus on the new menu's control and open the add-items panel? Thinking user flow...
+		},
+
+		/**
+		 * Select a default location.
+		 *
+		 * This method selects a single location by default so we can support
+		 * creating a menu for a specific menu location.
+		 *
+		 * @param {string} locationId - The ID of the location to select.
+		 *  Specifying `null` or `undefined` will clear all selections.
+		 */
+		selectDefaultLocation: function ( locationId ) {
+			var locationControl = api.control( this.id + '[locations]' ),
+				locationSelections = {};
+
+			if ( locationId !== undefined && locationId !== null ) {
+				locationSelections[ locationId ] = true;
+			}
+
+			locationControl.setSelections( locationSelections );
 		}
 	});
 
@@ -1427,6 +1447,13 @@
 					control.container.find( '.edit-menu' ).removeClass( 'hidden' );
 				}
 			});
+
+			// Create menu button.
+			control.container.find( '.create-menu' ).on( 'click', function () {
+				var addMenuSection = api.section( 'add_menu' );
+				addMenuSection.selectDefaultLocation( this.dataset.locationId );
+				addMenuSection.focus();
+			} );
 
 			// Add/remove menus from the available options when they are added and removed.
 			api.bind( 'add', function( setting ) {
@@ -2349,6 +2376,20 @@
 				} );
 				updateSelectedMenuLabel( navMenuLocationSetting.get() );
 			});
+		},
+
+		/**
+		 * Set the selected locations.
+		 *
+		 * This method sets the selected locations and allows us to do things like
+		 * set the default location for a new menu.
+		 *
+		 * @param {Object.<string,boolean>} selections - A map of location selections.
+		 */
+		setSelections: function ( selections ) {
+			this.container.find( '.menu-location' ).each( function( i, checkboxNode ) {
+				checkboxNode.checked = !! selections[ checkboxNode.dataset.locationId ];
+			} );
 		}
 	});
 

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1397,7 +1397,7 @@
 		 *  Specifying `null` will clear all selections.
 		 * @returns {void}
 		 */
-		selectDefaultLocation: function ( locationId ) {
+		selectDefaultLocation: function( locationId ) {
 			var locationControl = api.control( this.id + '[locations]' ),
 				locationSelections = {};
 
@@ -1439,7 +1439,7 @@
 			};
 
 			// Create and Edit menu buttons.
-			control.container.find( '.create-menu' ).on( 'click', function () {
+			control.container.find( '.create-menu' ).on( 'click', function() {
 				var addMenuSection = api.section( 'add_menu' );
 				addMenuSection.selectDefaultLocation( this.dataset.locationId );
 				addMenuSection.focus();
@@ -2389,7 +2389,7 @@
 		 * @param {Object.<string,boolean>} selections - A map of location selections.
 		 * @returns {void}
 		 */
-		setSelections: function ( selections ) {
+		setSelections: function( selections ) {
 			this.container.find( '.menu-location' ).each( function( i, checkboxNode ) {
 				var locationId = checkboxNode.dataset.locationId;
 				checkboxNode.checked = locationId in selections ? selections[ locationId ] : false;

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1438,25 +1438,22 @@
 				}
 			};
 
-			// Edit menu button.
-			control.container.find( '.edit-menu' ).on( 'click', function() {
-				var menuId = control.setting();
-				api.section( 'nav_menu[' + menuId + ']' ).focus();
-			});
-			control.setting.bind( 'change', function() {
-				if ( 0 === control.setting() ) {
-					control.container.find( '.edit-menu' ).addClass( 'hidden' );
-				} else {
-					control.container.find( '.edit-menu' ).removeClass( 'hidden' );
-				}
-			});
-
-			// Create menu button.
+			// Create and Edit menu buttons.
 			control.container.find( '.create-menu' ).on( 'click', function () {
 				var addMenuSection = api.section( 'add_menu' );
 				addMenuSection.selectDefaultLocation( this.dataset.locationId );
 				addMenuSection.focus();
 			} );
+			control.container.find( '.edit-menu' ).on( 'click', function() {
+				var menuId = control.setting();
+				api.section( 'nav_menu[' + menuId + ']' ).focus();
+			});
+			control.setting.bind( 'change', function() {
+				var menuIsSelected = 0 !== control.setting();
+				control.container.find( '.create-menu' ).toggleClass( 'hidden', menuIsSelected );
+				control.container.find( '.edit-menu' ).toggleClass( 'hidden', ! menuIsSelected );
+			});
+
 
 			// Add/remove menus from the available options when they are added and removed.
 			api.bind( 'add', function( setting ) {

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1391,14 +1391,17 @@
 		 * This method selects a single location by default so we can support
 		 * creating a menu for a specific menu location.
 		 *
-		 * @param {string} locationId - The ID of the location to select.
-		 *  Specifying `null` or `undefined` will clear all selections.
+		 * @since 4.9.0
+		 *
+		 * @param {string|null} locationId - The ID of the location to select.
+		 *  Specifying `null` will clear all selections.
+		 * @returns {void}
 		 */
 		selectDefaultLocation: function ( locationId ) {
 			var locationControl = api.control( this.id + '[locations]' ),
 				locationSelections = {};
 
-			if ( locationId !== undefined && locationId !== null ) {
+			if ( locationId !== null ) {
 				locationSelections[ locationId ] = true;
 			}
 
@@ -2384,11 +2387,15 @@
 		 * This method sets the selected locations and allows us to do things like
 		 * set the default location for a new menu.
 		 *
+		 * @since 4.9.0
+		 *
 		 * @param {Object.<string,boolean>} selections - A map of location selections.
+		 * @returns {void}
 		 */
 		setSelections: function ( selections ) {
 			this.container.find( '.menu-location' ).each( function( i, checkboxNode ) {
-				checkboxNode.checked = !! selections[ checkboxNode.dataset.locationId ];
+				var locationId = checkboxNode.dataset.locationId;
+				checkboxNode.checked = locationId in selections ? selections[ locationId ] : false;
 			} );
 		}
 	});

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1454,7 +1454,6 @@
 				control.container.find( '.edit-menu' ).toggleClass( 'hidden', ! menuIsSelected );
 			});
 
-
 			// Add/remove menus from the available options when they are added and removed.
 			api.bind( 'add', function( setting ) {
 				var option, menuId, matches = setting.id.match( navMenuIdRegex );

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-location-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-location-control.php
@@ -74,6 +74,7 @@ class WP_Customize_Nav_Menu_Location_Control extends WP_Customize_Control {
 			</select>
 		</label>
 		<button type="button" class="button-link edit-menu<?php if ( ! $this->value() ) { echo ' hidden'; } ?>" aria-label="<?php esc_attr_e( 'Edit selected menu' ); ?>"><?php _e( 'Edit Menu' ); ?></button>
+		<button type="button" class="button-link create-menu" data-location-id="<?php echo esc_attr( $this->location_id ); ?>" aria-label="<?php esc_attr_e( 'Create a menu for this location' ); ?>"><?php _e( '+ Create New Nenu' ); ?></button>
 		<?php
 	}
 }

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-location-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-location-control.php
@@ -73,8 +73,8 @@ class WP_Customize_Nav_Menu_Location_Control extends WP_Customize_Control {
 				?>
 			</select>
 		</label>
+		<button type="button" class="button-link create-menu<?php if ( $this->value() ) { echo ' hidden'; } ?>" data-location-id="<?php echo esc_attr( $this->location_id ); ?>" aria-label="<?php esc_attr_e( 'Create a menu for this location' ); ?>"><?php _e( '+ Create New Nenu' ); ?></button>
 		<button type="button" class="button-link edit-menu<?php if ( ! $this->value() ) { echo ' hidden'; } ?>" aria-label="<?php esc_attr_e( 'Edit selected menu' ); ?>"><?php _e( 'Edit Menu' ); ?></button>
-		<button type="button" class="button-link create-menu" data-location-id="<?php echo esc_attr( $this->location_id ); ?>" aria-label="<?php esc_attr_e( 'Create a menu for this location' ); ?>"><?php _e( '+ Create New Nenu' ); ?></button>
 		<?php
 	}
 }

--- a/tests/qunit/wp-admin/js/customize-nav-menus.js
+++ b/tests/qunit/wp-admin/js/customize-nav-menus.js
@@ -110,6 +110,7 @@ jQuery( window ).load( function (){
 
 	// @todo Add tests for api.Menus.NewMenuSection
 	// @todo Add tests for api.Menus.MenuLocationControl
+	// @todo Add tests for api.Menus.MenuLocationsControl
 	// @todo Add tests for api.Menus.MenuAutoAddControl
 	// @todo Add tests for api.Menus.MenuControl
 	// @todo Add tests for api.Menus.NewMenuControl


### PR DESCRIPTION
This is a PR for addressing [trac-36279](https://core.trac.wordpress.org/ticket/36279).

This adds a "Create New Menu" button per location dropdown to the All Locations panel. Each button expands the New Menu section and selects its location by default.
