### PR TITLE
Restore Customizer new menu control and section

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -3015,7 +3015,7 @@
 	 *
 	 * @constructor
 	 * @augments wp.customize.Control
-	 * @deprecated Since 4.9.0 when it fell out of use due to new menu creation UX.
+	 * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
 	 */
 	api.Menus.NewMenuControl = api.Control.extend({
 		/**

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1401,7 +1401,7 @@
 
 				if ( checkbox.prop( 'checked' ) ) {
 					navMenuLocationSetting = api( 'nav_menu_locations[' + checkbox.data( 'location-id' ) + ']' );
-					navMenuLocationSetting.set( placeholderId );
+					navMenuLocationSetting.set( menuSection.params.menu_id );
 
 					// Reset state for next new menu
 					checkbox.prop( 'checked', false );

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1415,7 +1415,7 @@
 				completeCallback: function() {
 					menuSection.highlightNewItemButton();
 				}
-			} ); // @todo should we focus on the new menu's control and open the add-items panel? Thinking user flow...
+			} );
 		},
 
 		/**

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -3094,7 +3094,7 @@
 			wp.a11y.speak( api.Menus.data.l10n.menuAdded );
 
 			// Focus on the new menu section.
-			menuSection.focus(); // @todo should we focus on the new menu's control and open the add-items panel? Thinking user flow...
+			menuSection.focus();
 		}
 	});
 

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -3107,7 +3107,7 @@
 		nav_menu_item: api.Menus.MenuItemControl,
 		nav_menu: api.Menus.MenuControl,
 		nav_menu_name: api.Menus.MenuNameControl,
-		new_menu: api.Menus.NewMenuControl,
+		new_menu: api.Menus.NewMenuControl, // @todo Remove in 5.0. See #42364.
 		nav_menu_locations: api.Menus.MenuLocationsControl,
 		nav_menu_auto_add: api.Menus.MenuAutoAddControl
 	});

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -769,6 +769,12 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-location
 
 /**
  * WP_Customize_Nav_Menu_Name_Control class.
+ *
+ * As this file is deprecated, it will trigger a deprecation notice if instantiated. In a subsequent
+ * release, the require_once() here will be removed and _deprecated_file() will be called if file is
+ * required at all.
+ *
+ * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -783,6 +783,11 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-location
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
 
 /**
+ * WP_Customize_New_Menu_Control class.
+ */
+require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' );
+
+/**
  * WP_Customize_Date_Time_Control class.
  */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-date-time-control.php' );

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -783,11 +783,6 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-location
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
 
 /**
- * WP_Customize_New_Menu_Control class.
- */
-require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' );
-
-/**
  * WP_Customize_Date_Time_Control class.
  */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-date-time-control.php' );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -317,7 +317,6 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-locations-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' );
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menus-panel.php' );
 

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -317,7 +317,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-locations-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' ); // @todo Remove in 5.0.
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' ); // @todo Remove in 5.0. See #42364.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menus-panel.php' );
 
@@ -325,7 +325,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-themes-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' ); // @todo Remove in 5.0.
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' ); // @todo Remove in 5.0. See #42364.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-custom-css-setting.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-filter-setting.php' );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -317,6 +317,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-locations-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' ); // @todo Remove in 5.0.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menus-panel.php' );
 
@@ -324,7 +325,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-themes-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' );
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' ); // @todo Remove in 5.0.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-custom-css-setting.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-filter-setting.php' );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -317,6 +317,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-locations-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' );
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menus-panel.php' );
 
@@ -324,6 +325,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-themes-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' );
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-custom-css-setting.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-filter-setting.php' );

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -688,11 +688,12 @@ final class WP_Customize_Nav_Menus {
 		}
 
 		// Add the add-new-menu section and controls.
-		$this->manager->add_section( new WP_Customize_New_Menu_Section( $this->manager, 'add_menu', array(
+		$this->manager->add_section( 'add_menu', array(
+			'type'     => 'new_menu',
 			'title'    => __( 'New Menu' ),
 			'panel'    => 'nav_menus',
 			'priority' => 20,
-		) ) );
+		) );
 
 		$this->manager->add_setting( new WP_Customize_Filter_Setting( $this->manager, 'nav_menus_created_posts', array(
 			'transport' => 'postMessage',

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -688,12 +688,11 @@ final class WP_Customize_Nav_Menus {
 		}
 
 		// Add the add-new-menu section and controls.
-		$this->manager->add_section( 'add_menu', array(
-			'type'     => 'new_menu',
+		$this->manager->add_section( new WP_Customize_New_Menu_Section( $this->manager, 'add_menu', array(
 			'title'    => __( 'New Menu' ),
 			'panel'    => 'nav_menus',
 			'priority' => 20,
-		) );
+		) ) );
 
 		$this->manager->add_setting( new WP_Customize_Filter_Setting( $this->manager, 'nav_menus_created_posts', array(
 			'transport' => 'postMessage',

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -385,3 +385,6 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.p
 
 /** WP_Customize_Nav_Menu_Section class */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
+
+/** WP_Customize_New_Menu_Section class */
+require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' );

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -386,5 +386,13 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.p
 /** WP_Customize_Nav_Menu_Section class */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
 
-/** WP_Customize_New_Menu_Section class */
+/**
+ * WP_Customize_New_Menu_Section class
+ *
+ * As this file is deprecated, it will trigger a deprecation notice if instantiated. In a subsequent
+ * release, the require_once() here will be removed and _deprecated_file() will be called if file is
+ * required at all.
+ *
+ * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
+ */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' );

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
+ * @deprecated Since 4.9.0 when it fell out of use due to new menu creation UX.
  */
 
 /**

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -5,13 +5,15 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
- * @deprecated Since 4.9.0 when it fell out of use due to new menu creation UX.
+ * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
+_deprecated_file( basename( __FILE__ ), '4.9.0' );
 
 /**
  * Customize control class for new menus.
  *
  * @since 4.3.0
+ * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
  *
  * @see WP_Customize_Control
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -7,7 +7,6 @@
  * @since 4.4.0
  * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
-_deprecated_file( basename( __FILE__ ), '4.9.0' );
 
 /**
  * Customize control class for new menus.
@@ -26,6 +25,20 @@ class WP_Customize_New_Menu_Control extends WP_Customize_Control {
 	 * @var string
 	 */
 	public $type = 'new_menu';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 4.9.0
+	 *
+	 * @param WP_Customize_Manager $manager Manager.
+	 * @param string               $id      ID.
+	 * @param array                $args    Args.
+	 */
+	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
+		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php.
+		parent::__construct( $manager, $id, $args );
+	}
 
 	/**
 	 * Render the control's content.

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -36,7 +36,7 @@ class WP_Customize_New_Menu_Control extends WP_Customize_Control {
 	 * @param array                $args    Args.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php.
+		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php. See #42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -5,14 +5,14 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
- * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
+ * @deprecated 4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
  */
 
 /**
  * Customize control class for new menus.
  *
  * @since 4.3.0
- * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
+ * @deprecated 4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
  *
  * @see WP_Customize_Control
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,8 +5,9 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
- * @deprecated Since 4.9.0 when this was replaced with a basic section type.
+ * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
+_deprecated_file( basename( __FILE__ ), '4.9.0' );
 
 /**
  * Customize Menu Section Class
@@ -14,6 +15,7 @@
  * Implements the new-menu-ui toggle button instead of a regular section.
  *
  * @since 4.3.0
+ * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
  *
  * @see WP_Customize_Section
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
+ * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
 
 /**
@@ -15,6 +16,7 @@
  * base class methods.
  *
  * @since 4.3.0
+ * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
  *
  * @see WP_Customize_Section
  */
@@ -27,4 +29,21 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 * @var string
 	 */
 	public $type = 'new_menu';
+
+	/**
+	 * Constructor.
+	 *
+	 * Any supplied $args override class property defaults.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
+	 * @param string               $id      An specific ID of the section.
+	 * @param array                $args    Section arguments.
+	 */
+	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
+		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php.
+		parent::__construct( $manager, $id, $args );
+	}
+
 }

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -42,4 +42,19 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 		parent::__construct( $manager, $id, $args );
 	}
 
+	/**
+	 * Render the section, and the controls that have been added to it.
+	 *
+	 * @since 4.3.0
+	 */
+	protected function render() {
+		?>
+		<li id="accordion-section-<?php echo esc_attr( $this->id ); ?>" class="accordion-section-new-menu">
+			<button type="button" class="button add-new-menu-item add-menu-toggle" aria-expanded="false">
+				<?php echo esc_html( $this->title ); ?>
+			</button>
+			<ul class="new-menu-section-content"></ul>
+		</li>
+		<?php
+	}
 }

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -38,7 +38,7 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 * @param array                $args    Section arguments.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php.
+		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php. See #42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,6 +5,7 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
+ * @deprecated Since 4.9.0 when this was replaced with a basic section type.
  */
 
 /**

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,18 +5,14 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
- * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
+ * @deprecated 4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
  */
 
 /**
  * Customize Menu Section Class
  *
- * Implements a section for creating new menus. This class now exists for
- * backwards compatibility, following earlier versions that overrode
- * base class methods.
- *
  * @since 4.3.0
- * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
+ * @deprecated 4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
  *
  * @see WP_Customize_Section
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,17 +5,16 @@
  * @package WordPress
  * @subpackage Customize
  * @since 4.4.0
- * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
  */
-_deprecated_file( basename( __FILE__ ), '4.9.0' );
 
 /**
  * Customize Menu Section Class
  *
- * Implements the new-menu-ui toggle button instead of a regular section.
+ * Implements a section for creating new menus. This class now exists for
+ * backwards compatibility, following earlier versions that overrode
+ * base class methods.
  *
  * @since 4.3.0
- * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
  *
  * @see WP_Customize_Section
  */
@@ -28,20 +27,4 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 * @var string
 	 */
 	public $type = 'new_menu';
-
-	/**
-	 * Render the section, and the controls that have been added to it.
-	 *
-	 * @since 4.3.0
-	 */
-	protected function render() {
-		?>
-		<li id="accordion-section-<?php echo esc_attr( $this->id ); ?>" class="accordion-section-new-menu">
-			<button type="button" class="button add-new-menu-item add-menu-toggle" aria-expanded="false">
-				<?php echo esc_html( $this->title ); ?>
-			</button>
-			<ul class="new-menu-section-content"></ul>
-		</li>
-		<?php
-	}
 }

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -31,7 +31,7 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 *
 	 * Any supplied $args override class property defaults.
 	 *
-	 * @since 3.4.0
+	 * @since 4.9.0
 	 *
 	 * @param WP_Customize_Manager $manager Customizer bootstrap instance.
 	 * @param string               $id      An specific ID of the section.

--- a/tests/qunit/wp-admin/js/customize-nav-menus.js
+++ b/tests/qunit/wp-admin/js/customize-nav-menus.js
@@ -113,7 +113,6 @@ jQuery( window ).load( function (){
 	// @todo Add tests for api.Menus.MenuLocationsControl
 	// @todo Add tests for api.Menus.MenuAutoAddControl
 	// @todo Add tests for api.Menus.MenuControl
-	// @todo Add tests for api.Menus.NewMenuControl
 	// @todo Add tests for api.Menus.applySavedData
 	// @todo Add tests for api.Menus.focusMenuItemControl
 

--- a/tests/qunit/wp-admin/js/customize-nav-menus.js
+++ b/tests/qunit/wp-admin/js/customize-nav-menus.js
@@ -115,6 +115,7 @@ jQuery( window ).load( function (){
 	// @todo Add tests for api.Menus.MenuControl
 	// @todo Add tests for api.Menus.applySavedData
 	// @todo Add tests for api.Menus.focusMenuItemControl
+	// @todo Add tests for api.Menus.createNavMenu
 
 	test( 'api.Menus.getMenuControl() should return the expected control', function() {
 		var control = api.Menus.getMenuControl( primaryMenuId );


### PR DESCRIPTION
This is a PR to address:
https://core.trac.wordpress.org/ticket/42357

The control and section classes for new menus are restored and marked
as deprecated.

The TODO for testing NewMenuControl is also removed due to deprecation.