### PR TITLE
Inits 19

### DIFF
--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -129,6 +129,7 @@ class WP {
 	 * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
 	 *
 	 * @param array|string $extra_query_vars Set the extra query variables.
+	 * @return bool Whether the request was parsed.
 	 */
 	public function parse_request( $extra_query_vars = '' ) {
 		global $wp_rewrite;
@@ -143,7 +144,7 @@ class WP {
 		 * @param array|string $extra_query_vars Extra passed query variables.
 		 */
 		if ( ! apply_filters( 'do_parse_request', true, $this, $extra_query_vars ) ) {
-			return;
+			return false;
 		}
 
 		$this->query_vars     = array();
@@ -394,6 +395,8 @@ class WP {
 		 * @param WP $wp Current WordPress environment instance (passed by reference).
 		 */
 		do_action_ref_array( 'parse_request', array( &$this ) );
+
+		return true;
 	}
 
 	/**
@@ -755,12 +758,13 @@ class WP {
 	 */
 	public function main( $query_args = '' ) {
 		$this->init();
-		$this->parse_request( $query_args );
+		$parsed = $this->parse_request( $query_args );
 		$this->send_headers();
-		$this->query_posts();
-		$this->handle_404();
-		$this->register_globals();
-
+		if ( $parsed ) {
+			$this->query_posts();
+			$this->handle_404();
+			$this->register_globals();
+		}
 		/**
 		 * Fires once the WordPress environment has been set up.
 		 *

--- a/tests/phpunit/tests/wp/parseRequest.php
+++ b/tests/phpunit/tests/wp/parseRequest.php
@@ -39,4 +39,20 @@ class Tests_WP_ParseRequest extends WP_UnitTestCase {
 		$this->wp->parse_request();
 		$this->assertSame( '', $this->wp->request );
 	}
+	/**
+	 * Test that the parse_request() returns bool
+	 *
+	 * @ticket 10886
+	 */
+	public function test_parse_request_returns_bool() {
+
+		// check if parse_request() returns true for default setup.
+		$this->assertTrue( $this->wp->parse_request(), 'returns true' );
+
+		// add filter to shortcut the parse_request function.
+		add_filter( 'do_parse_request', '__return_false' );
+		$this->assertFalse( $this->wp->parse_request(), 'returns false' );
+		remove_filter( 'do_parse_request', '__return_false' );
+
+	}
 }


### PR DESCRIPTION
Patch refresh that:
Added boolean returns to parse_request()
Add shortcut to stop load not needed calls to main() if parse_request() returns early
Add test to make sure parse_request() return boolean

Trac ticket: (https://core.trac.wordpress.org/ticket/10886