### PR TITLE
remove networks_have_paths cache key

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -1173,8 +1173,6 @@ function populate_network_meta( $network_id, array $meta = array() ) {
 		wp_cache_delete( $network_id, 'networks' );
 	}
 
-	wp_cache_delete( 'networks_have_paths', 'site-options' );
-
 	if ( ! is_multisite() ) {
 		$site_admins = array( $site_user->user_login );
 		$users       = get_users(

--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -353,17 +353,13 @@ class WP_Network {
 		 */
 		$using_paths = true;
 		if ( wp_using_ext_object_cache() ) {
-			$using_paths = wp_cache_get( 'networks_have_paths', 'site-options' );
-			if ( false === $using_paths ) {
-				$using_paths = get_networks(
-					array(
-						'number'       => 1,
-						'count'        => true,
-						'path__not_in' => '/',
-					)
-				);
-				wp_cache_add( 'networks_have_paths', $using_paths, 'site-options' );
-			}
+			$using_paths = get_networks(
+				array(
+					'number'       => 1,
+					'count'        => true,
+					'path__not_in' => '/',
+				)
+			);
 		}
 
 		$paths = array();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/42070<!-- insert a link to the WordPress Trac ticket here -->

Internal: https://xwp-co.atlassian.net/browse/INITS-501

**Note:** I did observe the number of queries before and after the call to `get_network_by_path` in `test_get_network_by_path` function. The number of queries with and without `networks_have_paths` cache were the same.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
