### PR TITLE
55461 Improve cache key generation in WP_Network_Query

### DIFF
--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -242,8 +242,8 @@ class WP_Network_Query {
 		// $args can include anything. Only use the args defined in the query_var_defaults to compute the key.
 		$_args = wp_array_slice_assoc( $this->query_vars, array_keys( $this->query_var_defaults ) );
 
-		// Ignore the $fields argument as the queried result will be the same regardless.
-		unset( $_args['fields'] );
+		// Ignore the $fields, $update_network_cache arguments as the queried result will be the same regardless.
+		unset( $_args['fields'], $_args['update_network_cache'] );
 
 		$key          = md5( serialize( $_args ) );
 		$last_changed = wp_cache_get_last_changed( 'networks' );

--- a/tests/phpunit/tests/multisite/wpNetworkQuery.php
+++ b/tests/phpunit/tests/multisite/wpNetworkQuery.php
@@ -510,6 +510,60 @@ if ( is_multisite() ) :
 		}
 
 		/**
+		 * @ticket 55461
+		 */
+		public function test_wp_network_query_cache_with_same_fields_same_cache_field() {
+			$q                 = new WP_Network_Query();
+			$query_1           = $q->query(
+				array(
+					'fields'               => 'all',
+					'number'               => 3,
+					'order'                => 'ASC',
+					'update_network_cache' => true,
+				)
+			);
+			$number_of_queries = get_num_queries();
+
+			$query_2 = $q->query(
+				array(
+					'fields'               => 'all',
+					'number'               => 3,
+					'order'                => 'ASC',
+					'update_network_cache' => true,
+				)
+			);
+
+			$this->assertSame( $number_of_queries, get_num_queries() );
+		}
+
+		/**
+		 * @ticket 55461
+		 */
+		public function test_wp_network_query_cache_with_same_fields_different_cache_field() {
+			$q                 = new WP_Network_Query();
+			$query_1           = $q->query(
+				array(
+					'fields'               => 'all',
+					'number'               => 3,
+					'order'                => 'ASC',
+					'update_network_cache' => true,
+				)
+			);
+			$number_of_queries = get_num_queries();
+
+			$query_2 = $q->query(
+				array(
+					'fields'               => 'all',
+					'number'               => 3,
+					'order'                => 'ASC',
+					'update_network_cache' => false,
+				)
+			);
+
+			$this->assertSame( $number_of_queries, get_num_queries() );
+		}
+
+		/**
 		 * @ticket 45749
 		 * @ticket 47599
 		 */


### PR DESCRIPTION
Improve cache key generation in WP_Network_Query unsetting update_network_cache

Trac ticket: [https://core.trac.wordpress.org/ticket/55461](https://core.trac.wordpress.org/ticket/55461)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
