### PR TITLE
[WIP] Add new 'async' parameter to enqueue/register style functions

### DIFF
--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -60,6 +60,14 @@ class _WP_Dependency {
 	public $args = null;  // Custom property, such as $in_footer or $media.
 
 	/**
+	 * Defer the loading of a stylesheet by using a temporary 'print' media until the
+     * page loads. Default false.
+	 *
+	 * @var array
+	 */
+	public $async = false;  // Custom property, such as $in_footer or $media.
+
+	/**
 	 * Extra data to supply to the handle.
 	 *
 	 * @since 2.6.0
@@ -93,7 +101,7 @@ class _WP_Dependency {
 	 * @param mixed ...$args Dependency information.
 	 */
 	public function __construct( ...$args ) {
-		list( $this->handle, $this->src, $this->deps, $this->ver, $this->args ) = $args;
+		list( $this->handle, $this->src, $this->deps, $this->ver, $this->args, $this->async ) = $args;
 		if ( ! is_array( $this->deps ) ) {
 			$this->deps = array();
 		}

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -250,13 +250,15 @@ class WP_Dependencies {
 	 *                                 If set to null, no version is added.
 	 * @param mixed            $args   Optional. Custom property of the item. NOT the class property $args.
 	 *                                 Examples: $media, $in_footer.
+	 * @param bool             $async  Optional. Defer the loading of a stylesheet by using a temporary 'print' media until the
+     *                                 page loads. Default false.
 	 * @return bool Whether the item has been registered. True on success, false on failure.
 	 */
-	public function add( $handle, $src, $deps = array(), $ver = false, $args = null ) {
+	public function add( $handle, $src, $deps = array(), $ver = false, $args = null, $async = false ) {
 		if ( isset( $this->registered[ $handle ] ) ) {
 			return false;
 		}
-		$this->registered[ $handle ] = new _WP_Dependency( $handle, $src, $deps, $ver, $args );
+		$this->registered[ $handle ] = new _WP_Dependency( $handle, $src, $deps, $ver, $args, $async );
 
 		// If the item was enqueued before the details were registered, enqueue it now.
 		if ( array_key_exists( $handle, $this->queued_before_register ) ) {

--- a/src/wp-includes/class.wp-styles.php
+++ b/src/wp-includes/class.wp-styles.php
@@ -278,6 +278,12 @@ class WP_Styles extends WP_Dependencies {
 			}
 		}
 
+		if ( $obj->async && ( false === strpos( $tag, "media='print'" ) ) ) {
+			$async_tag  = '<noscript>' . str_replace( " id='", " id='no-js-fallback-", $tag ) . '</noscript>';
+			$async_tag .= str_replace( " media='{$media}'", " media='print' onload='this.media=\"all\"'", $tag );
+			$tag = $async_tag;
+		}
+
 		if ( $this->do_concat ) {
 			$this->print_html .= $cond_before;
 			$this->print_html .= $tag;

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -124,12 +124,14 @@ function wp_add_inline_style( $handle, $data ) {
  * @param string           $media  Optional. The media for which this stylesheet has been defined.
  *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
  *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ * @param bool             $async  Optional. Defer the loading of a stylesheet by using a temporary 'print' media until the
+ *                                 page loads. Default false.
  * @return bool Whether the style has been registered. True on success, false on failure.
  */
-function wp_register_style( $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
+function wp_register_style( $handle, $src, $deps = array(), $ver = false, $media = 'all', $async = false ) {
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );
 
-	return wp_styles()->add( $handle, $src, $deps, $ver, $media );
+	return wp_styles()->add( $handle, $src, $deps, $ver, $media, $async );
 }
 
 /**
@@ -169,15 +171,17 @@ function wp_deregister_style( $handle ) {
  * @param string           $media  Optional. The media for which this stylesheet has been defined.
  *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
  *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ * @param bool             $async  Optional. Defer the loading of the stylesheet by using a temporary 'print' media until the
+ *                                 page loads. Default false.
  */
-function wp_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all' ) {
+function wp_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all', $async = false ) {
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );
 
 	$wp_styles = wp_styles();
 
 	if ( $src ) {
 		$_handle = explode( '?', $handle );
-		$wp_styles->add( $_handle[0], $src, $deps, $ver, $media );
+		$wp_styles->add( $_handle[0], $src, $deps, $ver, $media, $async );
 	}
 
 	$wp_styles->enqueue( $handle );


### PR DESCRIPTION
Adds a new 'async' param to wp_register_style() and wp_enqueue_style() functions. Defaults to false.
When true, use a temporary media="print" attribute until loading to avoid blocking rendering (along with a <noscript> fallback tag).

See https://github.com/WordPress/performance/issues/120.