### PR TITLE
Avoid duplicate query on empty collection request from WP REST

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -386,7 +386,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$page        = (int) $query_args['paged'];
 		$total_posts = $posts_query->found_posts;
 
-		if ( $total_posts < 1 ) {
+		if ( $total_posts < 1 && $page > 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count.
 			unset( $query_args['paged'] );
 

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -619,6 +619,31 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertSame( $id2, $data[0]['id'] );
 	}
 
+	/**
+	 * @ticket 55677
+	 */
+	public function test_get_items_avoid_duplicated_count_query_if_no_items() {
+		// Enable database queries logging.
+		if ( ! defined( 'SAVEQUERIES' ) ) {
+			define( 'SAVEQUERIES', true );
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$request->set_param( 'media_type', 'text' );
+		rest_get_server()->dispatch( $request );
+
+		global $wpdb;
+
+		// Extract all raw queries ran during the API request.
+		$raw_queries = array();
+		foreach ( $wpdb->queries as $query ) {
+			$raw_queries[] = $query[0];
+		}
+
+		// Check raw queries don't have any duplicates.
+		$this->assertTrue( count( $raw_queries ) === count( array_unique( $raw_queries ) ) );
+	}
+
 	public function test_get_item() {
 		$attachment_id = $this->factory->attachment->create_object(
 			$this->test_file,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -638,7 +638,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_get_items_avoid_duplicated_count_query_if_no_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_param( 'media_type', 'text' );
+		$request->set_param( 'media_type', 'video' );
 		rest_get_server()->dispatch( $request );
 
 		$this->assertCount( 1, $this->raw_queries );
@@ -649,7 +649,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_get_items_with_empty_page_runs_count_query_after() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
-		$request->set_param( 'media_type', 'text' );
+		$request->set_param( 'media_type', 'video' );
 		$request->set_param( 'page', 2 );
 		rest_get_server()->dispatch( $request );
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1385,8 +1385,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		// FIXME Since this request returns zero posts, the query is executed twice.
-		$this->assertCount( 2, $this->posts_clauses );
+		$this->assertCount( 1, $this->posts_clauses );
 		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
@@ -1417,8 +1416,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		// FIXME Since this request returns zero posts, the query is executed twice.
-		$this->assertCount( 2, $this->posts_clauses );
+		$this->assertCount( 1, $this->posts_clauses );
 		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );
@@ -1436,8 +1434,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		// FIXME Since this request returns zero posts, the query is executed twice.
-		$this->assertCount( 2, $this->posts_clauses );
+		$this->assertCount( 1, $this->posts_clauses );
 		$this->posts_clauses = array_slice( $this->posts_clauses, 0, 1 );
 
 		$this->assertPostsWhere( " AND {posts}.ID IN (0) AND {posts}.post_type = 'post' AND (({posts}.post_status = 'publish'))" );


### PR DESCRIPTION
JIRA Ticket: https://xwp-co.atlassian.net/browse/INITS-742
Trac Ticket: https://core.trac.wordpress.org/ticket/55677

## Issue

**WP REST API** has this logic to re-run the query without the page parameter if we didn't get any posts back from the main one. This is to handle the case where we requested an extra page of a collection that is empty. In that case, we want the API to return an empty collection, but still return the total number of items in that collection. Therefore that extra query gives that total back.

## Resolution

However, it previously didn't check if we were on the first page already. 
In that specific case, the second query would be the exact same as the first one and therefore wouldn't provide any additional value (the total of items would still be zero). This is why we sometimes ends up with a duplicated query.

## Testing instructions

- **Query Monitor** plugin should be enabled to detect any duplicate queries. 
- Open the gutenberg editor
- Open the JS console
- Type `await wp.apiFetch({ path: 'wp/v2/media?_envelope&media_type=text'}`
- The object returned should contain the number of duplicated queries

